### PR TITLE
Computer selects from own pieces

### DIFF
--- a/src/GameContext.js
+++ b/src/GameContext.js
@@ -4,7 +4,7 @@ import { GameHelpers, NullPiece } from './utils'
 
 const { Provider, Consumer } = React.createContext()
 
-const computerClockSpeed = 1000
+const computerClockSpeed = 500
 
 class GameProvider extends React.Component {
   state = {
@@ -22,8 +22,37 @@ class GameProvider extends React.Component {
   }
 
   tick = () => {
-    const tile = GameHelpers.generateRandomSelection()
-    this.selectComputerTile(tile)
+    const computerNextTile = this.getNextComputerTile()
+    this.selectComputerTile(computerNextTile)
+  }
+
+  getNextComputerTile = () => {
+    const { board, computerSelectedTile } = this.state
+    let nextTile
+    if (computerSelectedTile.rowIdx === null) {
+      nextTile = this.getRandomPieceTile("black")
+    } else {
+      const move = this.getRandomMove(board, computerSelectedTile)
+      if (move === null) {
+        nextTile = { rowIdx: null, colIdx: null }
+      } else {
+        nextTile = move
+      }
+    }
+    return nextTile
+  }
+
+  getRandomMove = (board, tile) => {
+    const piece = GameHelpers.getPiece(board, tile)
+    const validMoves = GameHelpers.validMoves(piece, tile)
+    return GameHelpers.sample(validMoves)
+  }
+
+  getRandomPieceTile = (color) => {
+    const { board } = this.state
+    const tiles = GameHelpers.playerPieces(board, color).
+      map((piece) => piece.tile)
+    return GameHelpers.sample(tiles)
   }
 
   resetBoard = () => {
@@ -50,6 +79,11 @@ class GameProvider extends React.Component {
     const { board } = this.state
     const { rowIdx: fromRow, colIdx: fromCol } = fromTile
     const { rowIdx: toRow, colIdx: toCol } = toTile
+
+    if (toRow === null && toCol === null) {
+      callBack({ rowIdx: null, colIdx: null})
+      return
+    }
 
     const toPiece = board[toRow][toCol]
 

--- a/src/utils/game_helpers.js
+++ b/src/utils/game_helpers.js
@@ -43,6 +43,42 @@ function createBoard() {
   return board
 }
 
+export function playerPieces(board, color) {
+  const pieces = []
+  for (i = 0; i < 8; i++) {
+    for (j = 0; j < 8; j++) {
+      piece = board[i][j]
+      if (piece.color === color) {
+        const tile = { rowIdx: i, colIdx: j }
+        const pieceWithTile = { piece, tile }
+        pieces.push(pieceWithTile)
+      }
+    }
+  }
+  return pieces
+}
+
+export function getPiece(board, tile) {
+  return board[tile.rowIdx][tile.colIdx]
+}
+
+export function validMoves(piece, tile) {
+  return piece.moves.map((move) => {
+    return { rowIdx: move[0] + tile.rowIdx, colIdx: move[1] + tile.colIdx }
+  }).filter((move) => {
+    return isOnBoard(move)
+  })
+}
+
+function isOnBoard(tile) {
+  return (
+    tile.rowIdx >= 0 &&
+    tile.rowIdx < 8 &&
+    tile.colIdx >= 0 &&
+    tile.rowIdx < 8
+  )
+}
+
 export function updateBoard(oldBoard, fromTile, toTile) {
   const { rowIdx: fromRow, colIdx: fromCol } = fromTile
   const { rowIdx: toRow, colIdx: toCol } = toTile
@@ -76,8 +112,8 @@ export function validMove(board, fromTile, toTile) {
   return ArrayHelpers.contains(availableTiles, toTile)
 }
 
-export function generateRandomSelection() {
-  return { rowIdx: getRandomInt(7), colIdx: getRandomInt(7) }
+export function sample(array) {
+  return (array.length === 0) ? null : array[getRandomInt(array.length)]
 }
 
 function getRandomInt(max) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,7 +5587,7 @@ react-native-gesture-handler@~1.0.14:
     invariant "^2.2.2"
     prop-types "^15.5.10"
 
-"react-native-maps@github:expo/react-native-maps#v0.22.1-exp.0":
+react-native-maps@expo/react-native-maps#v0.22.1-exp.0:
   version "0.22.1"
   resolved "https://codeload.github.com/expo/react-native-maps/tar.gz/e6f98ff7272e5d0a7fe974a41f28593af2d77bb2"
 


### PR DESCRIPTION
Why:
Currently the computer is just selecting tiles from random on the board.
We would like for the computer to select from its own pieces.

This commit:
Adds the logic for the computer to select randomly from its own pieces
and then select a random valid move for that piece. Note if there is no
valid move for that piece the computer will simply unselect its
selection.

---

### After

![smarter-computer-before](https://user-images.githubusercontent.com/16049495/57198499-92534980-6f41-11e9-9244-eb09609034c7.gif)

### Before

![smarter-computer-after](https://user-images.githubusercontent.com/16049495/57198504-9bdcb180-6f41-11e9-8394-e1f698c94ff0.gif)

