### PR TITLE
Introduce hooks

### DIFF
--- a/src/Game/Board.tsx
+++ b/src/Game/Board.tsx
@@ -1,26 +1,23 @@
-import React from "react"
+import React, { useContext } from "react"
 import { View, StyleSheet } from "react-native"
 
 import BoardRow from "./BoardRow"
-import { GameConsumer } from "../GameContext"
+import GameContext from "../GameContext"
 
-const Board = () => (
-  <GameConsumer>
-    {({ board }) => {
-      return (
-        <View style={styles.container}>
-          {board.map((row, rowIdx) => {
-            return (
-              <View style={styles.row} key={`row-${rowIdx}`}>
-                <BoardRow row={row} rowIdx={rowIdx} />
-              </View>
-            )
-          })}
-        </View>
-      )
-    }}
-  </GameConsumer>
-)
+const Board = () => {
+  const { board } = useContext(GameContext)
+  return (
+    <View style={styles.container}>
+      {board.map((row, rowIdx) => {
+        return (
+          <View style={styles.row} key={`row-${rowIdx}`}>
+            <BoardRow row={row} rowIdx={rowIdx} />
+          </View>
+        )
+      })}
+    </View>
+  )
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Game/BoardRow.tsx
+++ b/src/Game/BoardRow.tsx
@@ -1,57 +1,48 @@
-import React from "react"
+import React, { useContext } from "react"
 import { TouchableOpacity, View, StyleSheet } from "react-native"
 
 import Piece from "./Piece"
-import { GameConsumer } from "../GameContext"
 import { Piece as PieceType } from "../utils/pieces"
 import { Tile } from "../utils/game_helpers"
+import GameContext from "../GameContext"
 
 import { Color } from "../styles"
 
 const BoardRow = ({ row, rowIdx }: { row: any; rowIdx: number }) => {
+  const { userSelectedTile, computerSelectedTile, selectUserTile } = useContext(
+    GameContext
+  )
   return (
-    <GameConsumer>
-      {({
-        selectUserTile,
-        userSelectedTile,
-        computerSelectedTile,
-      }: {
-        selectUserTile: (tile: Tile) => void
-        userSelectedTile: Tile | null
-        computerSelectedTile: Tile | null
-      }) => (
-        <View style={styles.container}>
-          {row.map((piece: PieceType, colIdx: number) => {
-            let tile = { rowIdx, colIdx }
-            let tileStyle = createTileStyle(tile)
-            let userSelectedStyle = createSelectedStyle(
-              tile,
-              userSelectedTile,
-              Color.userHighlight
-            )
-            let computerSelectedStyle = createSelectedStyle(
-              tile,
-              computerSelectedTile,
-              Color.computerHighlight
-            )
-            return (
-              <TouchableOpacity
-                onPress={() => selectUserTile(tile)}
-                style={[
-                  styles.tile,
-                  tileStyle,
-                  userSelectedStyle,
-                  computerSelectedStyle,
-                ]}
-                key={`col-${colIdx}`}
-              >
-                <Piece piece={piece} />
-              </TouchableOpacity>
-            )
-          })}
-        </View>
-      )}
-    </GameConsumer>
+    <View style={styles.container}>
+      {row.map((piece: PieceType, colIdx: number) => {
+        let tile = { rowIdx, colIdx }
+        let tileStyle = createTileStyle(tile)
+        let userSelectedStyle = createSelectedStyle(
+          tile,
+          userSelectedTile,
+          Color.userHighlight
+        )
+        let computerSelectedStyle = createSelectedStyle(
+          tile,
+          computerSelectedTile,
+          Color.computerHighlight
+        )
+        return (
+          <TouchableOpacity
+            onPress={() => selectUserTile(tile)}
+            style={[
+              styles.tile,
+              tileStyle,
+              userSelectedStyle,
+              computerSelectedStyle,
+            ]}
+            key={`col-${colIdx}`}
+          >
+            <Piece piece={piece} />
+          </TouchableOpacity>
+        )
+      })}
+    </View>
   )
 }
 

--- a/src/Game/index.tsx
+++ b/src/Game/index.tsx
@@ -1,37 +1,34 @@
-import React from "react"
+import React, { useContext } from "react"
 import { TouchableOpacity, View, Text, StyleSheet } from "react-native"
 
 import Board from "./Board"
-import { GameConsumer } from "../GameContext"
+import GameContext from "../GameContext"
 
 import { Color } from "../styles"
 
-const GameScreen = ({ navigation }: { navigation: any }) => (
-  <GameConsumer>
-    {({ resetBoard }) => {
-      return (
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <Text>Real Time Chess</Text>
-          </View>
+const GameScreen = ({ navigation }: { navigation: any }) => {
+  const { resetBoard } = useContext(GameContext)
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text>Real Time Chess</Text>
+      </View>
 
-          <View style={styles.board}>
-            <Board />
-          </View>
+      <View style={styles.board}>
+        <Board />
+      </View>
 
-          <View style={styles.footer}>
-            <TouchableOpacity onPress={() => resetBoard()}>
-              <Text>Reset Board</Text>
-            </TouchableOpacity>
-            <TouchableOpacity onPress={() => navigation.navigate("Landing")}>
-              <Text>Go Back</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      )
-    }}
-  </GameConsumer>
-)
+      <View style={styles.footer}>
+        <TouchableOpacity onPress={() => resetBoard()}>
+          <Text>Reset Board</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate("Landing")}>
+          <Text>Go Back</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Why:
React Native 0.59 made hooks available. We would like to use hooks since
they provide a better primative for stateful logic reuse.

This commit:
Replaces the state and effect logic for the GameProvider and converts it
to a functional component.