### PR TITLE
Separate piece style from logic and improve types

### DIFF
--- a/src/Game/BoardRow.tsx
+++ b/src/Game/BoardRow.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react"
 import { TouchableOpacity, View, StyleSheet } from "react-native"
 
 import Piece from "./Piece"
-import { Piece as PieceType } from "../utils/pieces"
+import { PieceType } from "../utils/pieces"
 import { Tile } from "../utils/game_helpers"
 import GameContext from "../GameContext"
 

--- a/src/Game/Piece.tsx
+++ b/src/Game/Piece.tsx
@@ -1,13 +1,58 @@
 import React from "react"
-import { View, StyleSheet } from "react-native"
+import { View, StyleSheet, ViewStyle } from "react-native"
 
-import { Piece as PieceType } from "../utils/pieces"
+import { Pieces } from "../utils"
+import { Pieces as PieceStyles } from "../styles"
 
-const Piece = ({ piece }: { piece: PieceType }) => (
+const Piece = ({ piece }: { piece: Pieces.PieceInterface }) => (
   <View style={styles.container}>
-    <View style={[styles.piece, piece.style]} />
+    <View style={[styles.piece, pieceStyle(piece), pieceColor(piece)]} />
   </View>
 )
+
+const pieceStyle = (piece: Pieces.PieceType): ViewStyle => {
+  switch (piece.kind) {
+    case "empty": {
+      return PieceStyles.empty
+    }
+    case "pawn": {
+      return PieceStyles.pawn
+    }
+    case "knight": {
+      return PieceStyles.knight
+    }
+    case "bishop": {
+      return PieceStyles.bishop
+    }
+    case "rook": {
+      return PieceStyles.rook
+    }
+    case "queen": {
+      return PieceStyles.queen
+    }
+    case "king": {
+      return PieceStyles.king
+    }
+    default: {
+      console.error(`Piece: ${piece} has unknown kind: ${piece.kind}`)
+      return {}
+    }
+  }
+}
+
+const pieceColor = (piece: Pieces.PieceType): ViewStyle => {
+  switch (piece.side) {
+    case "black": {
+      return PieceStyles.black
+    }
+    case "white": {
+      return PieceStyles.white
+    }
+    default: {
+      return {}
+    }
+  }
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/GameContext.tsx
+++ b/src/GameContext.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useState, useEffect } from "react"
 
 import { GameHelpers } from "./utils"
-import { Piece } from "./utils/pieces"
-import { Tile } from "./utils/game_helpers"
+import { Tile, Board } from "./utils/game_helpers"
+import { Side } from "./utils/pieces"
 
 interface GameState {
   board: GameHelpers.Board
@@ -62,14 +62,14 @@ const GameProvider = ({ children }: GameProviderProps) => {
     }
   }
 
-  const getRandomMove = (board: Piece[][], tile: Tile): Tile | null => {
+  const getRandomMove = (board: Board, tile: Tile): Tile | null => {
     const piece = GameHelpers.getPiece(board, tile)
     const validMoves = GameHelpers.validMoves(piece, tile)
     return GameHelpers.sample<Tile>(validMoves)
   }
 
-  const getRandomPieceTile = (color: string): Tile | null => {
-    const tiles: Array<Tile> = GameHelpers.playerPieces(board, color).map(
+  const getRandomPieceTile = (side: Side): Tile | null => {
+    const tiles: Array<Tile> = GameHelpers.playerPieces(board, side).map(
       piece => piece.tile
     )
     return GameHelpers.sample(tiles)

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -11,3 +11,5 @@ export const tileWhite = lightGray
 export const userHighlight = yellow
 export const computerHighlight = purple
 export const pieceBorder = black
+export const blackPiece = black
+export const whitePiece = white

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,6 +1,7 @@
-import * as Color from './color'
-import * as Spacing from './spacing'
-import * as Buttons from './buttons'
-import * as Typography from './typography'
+import * as Buttons from "./buttons"
+import * as Color from "./color"
+import * as Pieces from "./pieces"
+import * as Spacing from "./spacing"
+import * as Typography from "./typography"
 
-export { Color, Spacing, Buttons, Typography }
+export { Buttons, Color, Pieces, Spacing, Typography }

--- a/src/styles/pieces.ts
+++ b/src/styles/pieces.ts
@@ -1,0 +1,54 @@
+import { ViewStyle } from "react-native"
+
+import * as Colors from "./color"
+
+export const black: ViewStyle = {
+  borderColor: Colors.pieceBorder,
+  backgroundColor: Colors.blackPiece,
+}
+
+export const white: ViewStyle = {
+  borderColor: Colors.pieceBorder,
+  backgroundColor: Colors.whitePiece,
+}
+
+export const empty: ViewStyle = {}
+
+export const pawn: ViewStyle = {
+  borderWidth: 2,
+  borderRadius: 15,
+  width: 20,
+  maxHeight: 20,
+}
+
+export const knight: ViewStyle = {
+  borderWidth: 2,
+  borderRadius: 6,
+  width: 20,
+}
+
+export const bishop: ViewStyle = {
+  width: 15,
+  maxHeight: 25,
+  borderWidth: 2,
+  transform: [{ skewX: "135deg" }],
+}
+
+export const rook: ViewStyle = {
+  borderWidth: 2,
+  width: 25,
+  height: 30,
+}
+
+export const queen: ViewStyle = {
+  borderWidth: 2,
+  transform: [{ rotate: "45deg" }],
+  width: 25,
+  maxHeight: 25,
+}
+
+export const king: ViewStyle = {
+  borderWidth: 2,
+  width: 25,
+  maxHeight: 25,
+}

--- a/src/utils/game_helpers.ts
+++ b/src/utils/game_helpers.ts
@@ -1,6 +1,7 @@
 import {
-  Piece,
-  nullPiece,
+  PieceType,
+  Side,
+  empty,
   pawn,
   knight,
   bishop,
@@ -10,10 +11,10 @@ import {
 } from "./pieces"
 import * as ArrayHelpers from "./array_helpers"
 
-const black = "black"
-const white = "white"
+const black: Side = "black"
+const white: Side = "white"
 
-export type Board = Piece[][]
+export type Board = PieceType[][]
 
 export interface Tile {
   rowIdx: number
@@ -22,12 +23,12 @@ export interface Tile {
 
 interface PieceWithTile {
   tile: Tile
-  piece: Piece
+  piece: PieceType
 }
 
 export const initialBoard = createBoard()
 
-function createBoard(): Piece[][] {
+function createBoard(): Board {
   const board = []
 
   board.push(createBlackKingRow())
@@ -42,7 +43,7 @@ function createBoard(): Piece[][] {
   return board
 }
 
-function createBlackKingRow(): Piece[] {
+function createBlackKingRow(): PieceType[] {
   return [
     new rook(black),
     new bishop(black),
@@ -55,7 +56,7 @@ function createBlackKingRow(): Piece[] {
   ]
 }
 
-function createWhiteKingRow(): Piece[] {
+function createWhiteKingRow(): PieceType[] {
   return [
     new rook(white),
     new bishop(white),
@@ -68,24 +69,27 @@ function createWhiteKingRow(): Piece[] {
   ]
 }
 
-function createPawnRow(color: string): Piece[] {
+function createPawnRow(side: Side): PieceType[] {
   return Array.apply(undefined, Array(8)).map(() => {
-    return new pawn(color)
+    return new pawn(side)
   })
 }
 
-function createNullRow(): Piece[] {
+function createNullRow(): PieceType[] {
   return Array.apply(undefined, Array(8)).map(() => {
-    return new nullPiece()
+    return new empty()
   })
 }
 
-export function playerPieces(board: Piece[][], color: string): PieceWithTile[] {
+export function playerPieces(
+  board: PieceType[][],
+  side: Side
+): PieceWithTile[] {
   const pieces = []
   for (let i = 0; i < 8; i++) {
     for (let j = 0; j < 8; j++) {
       const piece = board[i][j]
-      if (piece.color === color) {
+      if (piece.side === side) {
         const tile = { rowIdx: i, colIdx: j }
         const pieceWithTile = { piece, tile }
         pieces.push(pieceWithTile)
@@ -95,11 +99,11 @@ export function playerPieces(board: Piece[][], color: string): PieceWithTile[] {
   return pieces
 }
 
-export function getPiece(board: Piece[][], tile: Tile): Piece {
+export function getPiece(board: Board, tile: Tile): PieceType {
   return board[tile.rowIdx][tile.colIdx]
 }
 
-export function validMoves(piece: Piece, tile: Tile): Array<Tile> {
+export function validMoves(piece: PieceType, tile: Tile): Array<Tile> {
   return piece.moves
     .map(move => {
       return { rowIdx: move[0] + tile.rowIdx, colIdx: move[1] + tile.colIdx }
@@ -116,32 +120,28 @@ function isOnBoard(tile: Tile): boolean {
 }
 
 export function updateBoard(
-  oldBoard: Piece[][],
+  oldBoard: Board,
   fromTile: Tile,
   toTile: Tile
-): Piece[][] {
+): Board {
   const { rowIdx: fromRow, colIdx: fromCol } = fromTile
   const { rowIdx: toRow, colIdx: toCol } = toTile
   const oldPiece = oldBoard[fromRow][fromCol]
   if (oldPiece.isPiece) {
     const newBoard = ArrayHelpers.deepDup(oldBoard)
     newBoard[toRow][toCol] = oldPiece
-    newBoard[fromRow][fromCol] = new nullPiece()
+    newBoard[fromRow][fromCol] = new empty()
     return newBoard
   } else {
     return oldBoard
   }
 }
 
-export function validMove(
-  board: Piece[][],
-  fromTile: Tile,
-  toTile: Tile
-): boolean {
+export function validMove(board: Board, fromTile: Tile, toTile: Tile): boolean {
   const { rowIdx: fromRowIdx, colIdx: fromColIdx } = fromTile
-  const { moves, color } = board[fromRowIdx][fromColIdx]
+  const { moves, side } = board[fromRowIdx][fromColIdx]
   let availableTiles
-  if (color === black) {
+  if (side === black) {
     availableTiles = moves.map(move => ({
       rowIdx: fromRowIdx + move[0],
       colIdx: fromColIdx + move[1],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
-import * as ArrayHelpers from './array_helpers'
-import * as GameHelpers from './game_helpers'
-import * as Pieces from './pieces'
+import * as ArrayHelpers from "./array_helpers"
+import * as GameHelpers from "./game_helpers"
+import * as Pieces from "./pieces"
 
 export { ArrayHelpers, GameHelpers, Pieces }

--- a/src/utils/pieces.ts
+++ b/src/utils/pieces.ts
@@ -1,47 +1,40 @@
-import { Color } from "../styles"
+type Side = "black" | "white" | ""
 
-export interface Piece {
-  color: string
+interface Piece {
+  kind: string
+  side: Side
   isPiece: boolean
-  name: string
-  style: object
   moves: number[][]
 }
 
-const nullPiece = (function nullPiece(this: Piece) {
-  this.color = ""
+interface Empty extends Piece {}
+interface Pawn extends Piece {}
+interface Knight extends Piece {}
+interface Bishop extends Piece {}
+interface Rook extends Piece {}
+interface Queen extends Piece {}
+interface King extends Piece {}
+
+type PieceType = Empty | Pawn | Knight | Bishop | Rook | Queen | King
+
+const empty = (function empty(this: Empty) {
+  this.kind = "empty"
+  this.side = ""
   this.isPiece = false
-  this.name = "Null"
-  this.style = {}
   this.moves = []
-} as any) as { new (): Piece }
+} as any) as { new (): Empty }
 
-const pawn = (function pawn(this: Piece, color: string) {
-  this.color = color
+const pawn = (function pawn(this: Pawn, side: Side) {
+  this.kind = "pawn"
+  this.side = side
   this.isPiece = true
-  this.name = "Pawn"
-  this.style = {
-    backgroundColor: color,
-    borderWidth: 2,
-    borderRadius: 15,
-    width: 20,
-    maxHeight: 20,
-    borderColor: Color.pieceBorder,
-  }
   this.moves = [[1, 0]]
-} as any) as { new (color: string): Piece }
+} as any) as { new (side: Side): Pawn }
 
-const knight = (function knight(this: Piece, color: string) {
-  this.color = color
+const knight = (function knight(this: Knight, side: Side) {
+  this.kind = "knight"
+  this.side = side
   this.isPiece = true
-  this.name = "Knight"
-  this.style = {
-    backgroundColor: color,
-    borderWidth: 2,
-    borderRadius: 6,
-    width: 20,
-    borderColor: Color.pieceBorder,
-  }
   this.moves = [
     [2, -1],
     [2, 1],
@@ -52,61 +45,33 @@ const knight = (function knight(this: Piece, color: string) {
     [-1, -2],
     [1, -2],
   ]
-} as any) as { new (color: string): Piece }
+} as any) as { new (side: Side): Knight }
 
-const bishop = (function bishop(this: Piece, color: string) {
-  this.color = color
+const bishop = (function bishop(this: Bishop, side: Side) {
+  this.kind = "bishop"
+  this.side = side
   this.isPiece = true
-  this.name = "Bishop"
-  this.style = {
-    backgroundColor: color,
-    width: 15,
-    maxHeight: 25,
-    borderWidth: 2,
-    transform: [{ skewX: "135deg" }],
-  }
   this.moves = generateBishopMoves()
-} as any) as { new (color: string): Piece }
+} as any) as { new (side: Side): Bishop }
 
-const rook = (function rook(this: Piece, color: string) {
-  this.color = color
+const rook = (function rook(this: Rook, side: Side) {
+  this.kind = "rook"
+  this.side = side
   this.isPiece = true
-  this.name = "Rook"
-  this.style = {
-    backgroundColor: color,
-    borderWidth: 2,
-    width: 25,
-    height: 30,
-  }
   this.moves = generateRookMoves()
-} as any) as { new (color: string): Piece }
+} as any) as { new (side: Side): Rook }
 
-const queen = (function queen(this: Piece, color: string) {
-  this.color = color
+const queen = (function queen(this: Queen, side: Side) {
+  this.kind = "queen"
+  this.side = side
   this.isPiece = true
-  this.name = "Queen"
-  this.style = {
-    backgroundColor: color,
-    borderWidth: 2,
-    transform: [{ rotate: "45deg" }],
-    width: 25,
-    maxHeight: 25,
-  }
   this.moves = generateQueenMoves()
-} as any) as { new (color: string): Piece }
+} as any) as { new (side: Side): Queen }
 
-const king = (function king(this: Piece, color: string) {
-  this.color = color
+const king = (function king(this: King, side: Side) {
+  this.kind = "king"
+  this.side = side
   this.isPiece = true
-  this.name = "King"
-  this.style = {
-    backgroundColor: color,
-    borderWidth: 15,
-    borderLeftColor: Color.tileBlack,
-    borderRightColor: Color.tileBlack,
-    borderTopColor: color,
-    borderBottomColor: color,
-  }
   this.moves = [
     [1, 0],
     [1, 1],
@@ -117,7 +82,7 @@ const king = (function king(this: Piece, color: string) {
     [0, -1],
     [1, -1],
   ]
-} as any) as { new (color: string): Piece }
+} as any) as { new (side: Side): King }
 
 function generateQueenMoves() {
   let moves = []
@@ -156,4 +121,16 @@ function generateRookMoves() {
   return moves
 }
 
-export { nullPiece, pawn, knight, bishop, rook, queen, king }
+export { empty, pawn, knight, bishop, rook, queen, king }
+export {
+  Piece as PieceInterface,
+  PieceType,
+  Side,
+  Empty,
+  Pawn,
+  Knight,
+  Bishop,
+  Rook,
+  Queen,
+  King,
+}


### PR DESCRIPTION
Why:
Currenlty the piece objects are responsible for both game logic and
stylistic concerns. This is a point of coupling which will make it
challenging to do refactors and development of the game logic without
affecting the styles and vice versa. We would like to keep these
concerns separate.

This commit:
Removes the styles from the piece objects, moves them into a
`styles/pieces.ts` file, and introduces logic to the rn component for
correctly rendering the right style for the pieces. The piece type
information was also improved a bit as well.