### PR TITLE
Refactor piece style application

### DIFF
--- a/src/Game/Piece.tsx
+++ b/src/Game/Piece.tsx
@@ -4,54 +4,36 @@ import { View, StyleSheet, ViewStyle } from "react-native"
 import { Pieces } from "../utils"
 import { Pieces as PieceStyles } from "../styles"
 
-const Piece = ({ piece }: { piece: Pieces.PieceInterface }) => (
-  <View style={styles.container}>
-    <View style={[styles.piece, pieceStyle(piece), pieceColor(piece)]} />
+interface PieceProps {
+  piece: Pieces.PieceInterface
+  testID?: string
+}
+
+const Piece = ({ piece, testID }: PieceProps) => (
+  <View style={styles.container} testID={testID}>
+    <View style={[styles.piece, ...pieceStyle(piece)]} />
   </View>
 )
 
-const pieceStyle = (piece: Pieces.PieceType): ViewStyle => {
-  switch (piece.kind) {
-    case "empty": {
-      return PieceStyles.empty
-    }
-    case "pawn": {
-      return PieceStyles.pawn
-    }
-    case "knight": {
-      return PieceStyles.knight
-    }
-    case "bishop": {
-      return PieceStyles.bishop
-    }
-    case "rook": {
-      return PieceStyles.rook
-    }
-    case "queen": {
-      return PieceStyles.queen
-    }
-    case "king": {
-      return PieceStyles.king
-    }
-    default: {
-      console.error(`Piece: ${piece} has unknown kind: ${piece.kind}`)
-      return {}
-    }
-  }
-}
+type PieceFlags = { [P in Pieces.FenCode]: ViewStyle[] }
 
-const pieceColor = (piece: Pieces.PieceType): ViewStyle => {
-  switch (piece.side) {
-    case "black": {
-      return PieceStyles.black
-    }
-    case "white": {
-      return PieceStyles.white
-    }
-    default: {
-      return {}
-    }
+const pieceStyle = (piece: Pieces.PieceType): ViewStyle[] => {
+  const styleMap: PieceFlags = {
+    "0": [PieceStyles.empty],
+    r: [PieceStyles.rook, PieceStyles.black],
+    n: [PieceStyles.knight, PieceStyles.black],
+    b: [PieceStyles.bishop, PieceStyles.black],
+    q: [PieceStyles.queen, PieceStyles.black],
+    k: [PieceStyles.king, PieceStyles.black],
+    p: [PieceStyles.pawn, PieceStyles.black],
+    R: [PieceStyles.rook, PieceStyles.white],
+    N: [PieceStyles.knight, PieceStyles.white],
+    B: [PieceStyles.bishop, PieceStyles.white],
+    Q: [PieceStyles.queen, PieceStyles.white],
+    K: [PieceStyles.king, PieceStyles.white],
+    P: [PieceStyles.pawn, PieceStyles.white],
   }
+  return styleMap[piece.fenCode]
 }
 
 const styles = StyleSheet.create({

--- a/src/specs/Game/Piece.spec.tsx
+++ b/src/specs/Game/Piece.spec.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { render, cleanup } from "@testing-library/react-native"
+import "@testing-library/jest-native/extend-expect"
+
+import Piece from "../../Game/Piece"
+import { rook } from "../../utils/pieces"
+
+afterEach(cleanup)
+
+describe("Piece", () => {
+  test("it renders with a provided piece prop", () => {
+    const piece = new rook("black")
+    const { getByTestId } = render(<Piece piece={piece} testID={"rook"} />)
+
+    expect(getByTestId("rook")).toBeDefined()
+  })
+})

--- a/src/utils/game_helpers.ts
+++ b/src/utils/game_helpers.ts
@@ -204,7 +204,12 @@ export function validMoves(board: Board, side: Side): Array<Move> {
   const fen = generateFen(board, side)
   const validation = chessInstance.validate_fen(fen)
   if (validation.valid) {
-    return chessInstance.moves({ verbose: true })
+    try {
+      return chessInstance.moves({ verbose: true })
+    } catch (e) {
+      console.log("chess instance errored looking for moves for: ", fen)
+      return []
+    }
   } else {
     console.log("invalid fen: ", validation)
     return []

--- a/src/utils/pieces.ts
+++ b/src/utils/pieces.ts
@@ -1,10 +1,25 @@
 import { Side } from "./game_helpers"
 
+type FenCode =
+  | "r"
+  | "n"
+  | "b"
+  | "k"
+  | "q"
+  | "p"
+  | "R"
+  | "N"
+  | "B"
+  | "K"
+  | "Q"
+  | "P"
+  | "0"
+
 interface Piece {
   kind: string
   side: Side | null
   isPiece: boolean
-  fenCode: string
+  fenCode: FenCode
 }
 
 interface Empty extends Piece {}
@@ -70,6 +85,7 @@ export { empty, pawn, knight, bishop, rook, queen, king }
 export {
   Piece as PieceInterface,
   PieceType,
+  FenCode,
   Empty,
   Pawn,
   Knight,


### PR DESCRIPTION
Why:
In a future commit we would like to switch out the current method of
building pieces images by applying view styles with image assets.

This commit:
Refactors the Piece component such that it will be easier to make this
change. No functionality has been added or changed.

Also caught in this pr was an opportunistic bug fix in the validMoves
function. there are some board configurations that will cause the
chess.js chess client to throw an error even though the client will
validate that configuration as valid.