### PR TITLE
Pawn can promote to queens

### DIFF
--- a/src/GameContext.tsx
+++ b/src/GameContext.tsx
@@ -134,6 +134,8 @@ const GameProvider = ({ children }: GameProviderProps) => {
       if (GameHelpers.validMove(board, fromTile, toTile, side)) {
         movePiece(fromTile, toTile)
         callBack(null)
+      } else {
+        console.log("not a valid move: ", fromTile, toTile, side)
       }
     }
   }

--- a/src/specs/utils/game_helpers.spec.ts
+++ b/src/specs/utils/game_helpers.spec.ts
@@ -10,6 +10,7 @@ import {
   tileANtoRC,
   generateFen,
   boardToAscii,
+  updateBoard,
 } from "../../utils/game_helpers"
 import { BoardFixtures } from "../__fixtures__"
 
@@ -94,6 +95,23 @@ describe("validMove", () => {
 
       expect(pa7a8).toBeTruthy()
       expect(Ng1g3).toBeTruthy()
+    })
+  })
+
+  describe("when the move is a pawn promotion", () => {
+    test("it returns true", () => {
+      const startBoard: Board = createBoard(
+        "rnbqkbnr/pPpppppp/8/8/8/8/1PPPPPPP/RNBQKBNR b KQkq - 0 1"
+      )
+
+      const result: boolean = validMove(
+        startBoard,
+        { rowIdx: 1, colIdx: 1 },
+        { rowIdx: 0, colIdx: 0 },
+        "white"
+      )
+
+      expect(result).toBeTruthy()
     })
   })
 
@@ -192,3 +210,48 @@ describe("winner", () => {
     })
   })
 })
+
+describe("updateBoard", () => {
+  describe("When provided an intial board and a move", () => {
+    test("it creates an a new board with the move applied", () => {
+      const initialBoard: Board = createBoard()
+
+      const result: Board = updateBoard(
+        initialBoard,
+        { rowIdx: 6, colIdx: 0 },
+        { rowIdx: 5, colIdx: 0 }
+      )
+
+      const expectedFen =
+        "rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq - 0 1"
+      const expected: Board = createBoard(expectedFen)
+
+      expectBoardsToMatch(result, expected)
+    })
+  })
+
+  describe("when a pawn moves to the back row", () => {
+    test("the pawn is promoted to a queen", () => {
+      const startBoard: Board = createBoard(
+        "rnbqkbnr/pPpppppp/8/8/8/8/1PPPPPPP/RNBQKBNR b KQkq - 0 1"
+      )
+
+      const result: Board = updateBoard(
+        startBoard,
+        { rowIdx: 1, colIdx: 1 },
+        { rowIdx: 0, colIdx: 0 }
+      )
+
+      const expectedFen =
+        "Qnbqkbnr/p1pppppp/8/8/8/8/1PPPPPPP/RNBQKBNR b KQkq - 0 1"
+      const expected: Board = createBoard(expectedFen)
+      expectBoardsToMatch(result, expected)
+    })
+  })
+})
+
+const expectBoardsToMatch = (testResult: Board, expected: Board) => {
+  const expectedAscii = boardToAscii(expected)
+  const resultAscii = boardToAscii(testResult)
+  expect(resultAscii).toStrictEqual(expectedAscii)
+}

--- a/src/utils/pieces.ts
+++ b/src/utils/pieces.ts
@@ -17,7 +17,7 @@ export type FenCode =
 
 interface Piece {
   kind: string
-  side: Side | null
+  side?: Side
   isPiece: boolean
   fenCode: FenCode
 }
@@ -34,7 +34,7 @@ type PieceType = Empty | Pawn | Knight | Bishop | Rook | Queen | King
 
 const empty = (function empty(this: Empty) {
   this.kind = "empty"
-  this.side = null
+  this.side = undefined
   this.isPiece = false
   this.fenCode = "0"
 } as any) as { new (): Empty }


### PR DESCRIPTION
Why:
Currently pawns are not allow to move to the back row. We would like for
pawns to be automatically promoted to queens when they enter the back
row.

This commit:
Updates the validMove function to consider pawns moving to the back row as
valid and updates the updateBaord function to promote pawns to queens as
they move onto the back row.

---

# gif

![pawns-promote](https://user-images.githubusercontent.com/16049495/66273249-2e121a00-e840-11e9-9c7a-016078fb93b8.gif)
