### PR TITLE
Only start game on game screen

### DIFF
--- a/src/Game/Board.tsx
+++ b/src/Game/Board.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react"
 import { View, StyleSheet } from "react-native"
 
 import BoardRow from "./BoardRow"
-import GameContext from "../GameContext"
+import GameContext from "./GameContext"
 
 import { Layout } from "../styles"
 

--- a/src/Game/BoardRow.tsx
+++ b/src/Game/BoardRow.tsx
@@ -4,7 +4,7 @@ import { TouchableOpacity, View, StyleSheet } from "react-native"
 import Piece from "./Piece"
 import { PieceType } from "../utils/pieces"
 import { Tile } from "../utils/game_helpers"
-import GameContext from "../GameContext"
+import GameContext from "./GameContext"
 
 import { Color } from "../styles"
 

--- a/src/Game/Game.tsx
+++ b/src/Game/Game.tsx
@@ -1,0 +1,68 @@
+import React, { useContext } from "react"
+import { View, TouchableOpacity, Text, StyleSheet } from "react-native"
+
+import Board from "./Board"
+import GameOver from "./GameOver"
+import GameContext from "./GameContext"
+
+import { Color, Typography, Buttons, Spacing } from "../styles"
+
+const Game = () => {
+  const { resetBoard, winner } = useContext(GameContext)
+
+  return (
+    <View style={styles.container} testID={"game"}>
+      <View style={styles.activeGameContainer}>
+        {winner == null ? <Board /> : <GameOver winner={winner} />}
+      </View>
+
+      <View style={styles.footer}>
+        {winner == null ? (
+          <TouchableOpacity onPress={() => resetBoard()}>
+            <Text style={styles.resetButton}>Reset Board</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity
+              onPress={() => resetBoard()}
+              style={styles.button}
+            >
+              <Text style={Typography.mainButton}>PLAY AGAIN</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  activeGameContainer: {
+    flex: 5,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  footer: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: Spacing.medium,
+    paddingBottom: Spacing.xLarge,
+  },
+  resetButton: {
+    color: Color.white,
+  },
+  buttonContainer: {
+    width: "100%",
+    ...Buttons.primaryContainer,
+  },
+  button: {
+    ...Buttons.primary,
+  },
+})
+
+export default Game

--- a/src/Game/GameContext.tsx
+++ b/src/Game/GameContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useEffect } from "react"
 
-import { AiHelpers, GameHelpers } from "./utils"
-import { Side } from "./utils/game_helpers"
+import { AiHelpers, GameHelpers } from "../utils"
+import { Side } from "../utils/game_helpers"
 
 export interface GameState {
   board: GameHelpers.Board

--- a/src/Game/index.tsx
+++ b/src/Game/index.tsx
@@ -1,15 +1,12 @@
-import React, { useContext } from "react"
-import { Image, TouchableOpacity, View, Text, StyleSheet } from "react-native"
+import React from "react"
+import { Image, View, StyleSheet } from "react-native"
 
-import Board from "./Board"
-import GameOver from "./GameOver"
-import GameContext from "../GameContext"
+import { GameProvider } from "./GameContext"
+import Game from "./Game"
 
-import { Color, Typography, Buttons, Spacing } from "../styles"
+import { Color } from "../styles"
 
 const GameScreen = () => {
-  const { resetBoard, winner } = useContext(GameContext)
-
   return (
     <View style={styles.container} testID={"game-screen"}>
       <View style={styles.header}>
@@ -22,25 +19,10 @@ const GameScreen = () => {
         </View>
       </View>
 
-      <View style={styles.activeGameContainer}>
-        {winner == null ? <Board /> : <GameOver winner={winner} />}
-      </View>
-
-      <View style={styles.footer}>
-        {winner == null ? (
-          <TouchableOpacity onPress={() => resetBoard()}>
-            <Text style={styles.heading}>Reset Board</Text>
-          </TouchableOpacity>
-        ) : (
-          <View style={styles.buttonContainer}>
-            <TouchableOpacity
-              onPress={() => resetBoard()}
-              style={styles.button}
-            >
-              <Text style={Typography.mainButton}>PLAY AGAIN</Text>
-            </TouchableOpacity>
-          </View>
-        )}
+      <View style={{ flex: 5 }}>
+        <GameProvider>
+          <Game />
+        </GameProvider>
       </View>
     </View>
   )
@@ -49,6 +31,7 @@ const GameScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    justifyContent: "flex-start",
     backgroundColor: Color.background,
   },
   header: {
@@ -62,29 +45,6 @@ const styles = StyleSheet.create({
   headerImage: {
     flex: 1,
     width: undefined,
-  },
-  heading: {
-    color: Color.white,
-  },
-  activeGameContainer: {
-    flex: 5,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  footer: {
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: Spacing.medium,
-    paddingBottom: Spacing.xLarge,
-  },
-  buttonContainer: {
-    width: "100%",
-    ...Buttons.primaryContainer,
-  },
-  button: {
-    ...Buttons.primary,
   },
 })
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,6 @@ import {
   View,
 } from "react-native"
 
-import { GameProvider } from "./GameContext"
 import AppNavigatorContainer from "./AppNavigatorContainer"
 
 import { Color } from "./styles"
@@ -27,9 +26,7 @@ const RealTimeChess = () => {
     <View style={{ flex: 1 }}>
       <GeneralStatusBar />
       <SafeAreaView style={{ flex: 1 }}>
-        <GameProvider>
-          <AppNavigatorContainer />
-        </GameProvider>
+        <AppNavigatorContainer />
       </SafeAreaView>
     </View>
   )

--- a/src/specs/Game/Game.spec.tsx
+++ b/src/specs/Game/Game.spec.tsx
@@ -1,0 +1,66 @@
+import React from "react"
+import { render, cleanup, wait } from "@testing-library/react-native"
+import "@testing-library/jest-native/extend-expect"
+
+import Game from "../../Game/Game"
+import GameContext, {
+  GameState,
+  initialGameState,
+} from "../../Game/GameContext"
+import { BoardFixtures } from "../__fixtures__"
+
+afterEach(cleanup)
+
+const renderGameScreen = (value: GameState) => {
+  return render(
+    <GameContext.Provider value={value}>
+      <Game />
+    </GameContext.Provider>
+  )
+}
+
+describe("Game", () => {
+  test("it renders with default game state", () => {
+    const { getByTestId } = renderGameScreen(initialGameState)
+
+    expect(getByTestId("game")).toBeDefined()
+  })
+
+  describe("when the game is over", () => {
+    describe("and when black has won the game", () => {
+      test("a 'You Lose' message is visable", async () => {
+        const gameState: GameState = {
+          board: BoardFixtures.blackWonGame,
+          userSelectedTile: null,
+          computerSelectedTile: null,
+          winner: "black",
+          resetBoard: jest.fn(),
+          selectUserTile: jest.fn(),
+        }
+        const { queryByTestId } = renderGameScreen(gameState)
+
+        await wait()
+
+        expect(queryByTestId("game-over-lose")).not.toBe(null)
+        expect(queryByTestId("game-over-win")).toBe(null)
+      })
+    })
+
+    describe("and when white has won the game", () => {
+      test("a 'You Won' message is visable", () => {
+        const gameState: GameState = {
+          board: BoardFixtures.whiteWonGame,
+          userSelectedTile: null,
+          computerSelectedTile: null,
+          winner: "white",
+          resetBoard: jest.fn(),
+          selectUserTile: jest.fn(),
+        }
+        const { queryByTestId } = renderGameScreen(gameState)
+
+        expect(queryByTestId("game-over-lose")).toBe(null)
+        expect(queryByTestId("game-over-win")).not.toBe(null)
+      })
+    })
+  })
+})

--- a/src/specs/Game/index.spec.tsx
+++ b/src/specs/Game/index.spec.tsx
@@ -1,61 +1,14 @@
 import React from "react"
 import { render, cleanup } from "@testing-library/react-native"
-import "@testing-library/jest-native/extend-expect"
 
 import GameScreen from "../../Game"
-import GameContext, { GameState, initialGameState } from "../../GameContext"
-import { BoardFixtures } from "../__fixtures__"
 
 afterEach(cleanup)
 
-const renderGameScreen = (value: GameState) => {
-  return render(
-    <GameContext.Provider value={value}>
-      <GameScreen />
-    </GameContext.Provider>
-  )
-}
-
 describe("GameScreen", () => {
-  test("it renders with default game state", () => {
-    const { getByTestId } = renderGameScreen(initialGameState)
+  test("it renders", () => {
+    const { getByTestId } = render(<GameScreen />)
 
     expect(getByTestId("game-screen")).toBeDefined()
-  })
-
-  describe("when the game is over", () => {
-    describe("and when black has won the game", () => {
-      test("a 'You Lose' message is visable", () => {
-        const gameState: GameState = {
-          board: BoardFixtures.blackWonGame,
-          userSelectedTile: null,
-          computerSelectedTile: null,
-          winner: "black",
-          resetBoard: jest.fn(),
-          selectUserTile: jest.fn(),
-        }
-        const { queryByTestId } = renderGameScreen(gameState)
-
-        expect(queryByTestId("game-over-lose")).not.toBe(null)
-        expect(queryByTestId("game-over-win")).toBe(null)
-      })
-    })
-
-    describe("and when white has won the game", () => {
-      test("a 'You Won' message is visable", () => {
-        const gameState: GameState = {
-          board: BoardFixtures.whiteWonGame,
-          userSelectedTile: null,
-          computerSelectedTile: null,
-          winner: "white",
-          resetBoard: jest.fn(),
-          selectUserTile: jest.fn(),
-        }
-        const { queryByTestId } = renderGameScreen(gameState)
-
-        expect(queryByTestId("game-over-lose")).toBe(null)
-        expect(queryByTestId("game-over-win")).not.toBe(null)
-      })
-    })
   })
 })


### PR DESCRIPTION
Why:
Currently the game starts as soon as the app loads the welcome screen.
We would like for the game to only start after the user as pressed play
on the welcome screen and have navigated to the game board.

This commit:
Moves the GameProvider to wrap only the game screen and not the
AppNavigatorContainer. This will case the game context to only render
(and thus start the game) after the user has navigated to the game
screen.

---

### Before

![start-after-press-play-before](https://user-images.githubusercontent.com/16049495/66356869-ad841400-e93a-11e9-9020-588ff425b848.gif)


### After

![start-after-press-play](https://user-images.githubusercontent.com/16049495/66356882-b5dc4f00-e93a-11e9-8781-6afaa111a8a4.gif)
