### PR TITLE
fix safearea background color

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ import AppNavigatorContainer from "./AppNavigatorContainer"
 import { Color } from "./styles"
 
 const GeneralStatusBar = () => (
-  <View style={[styles.statusBar, { backgroundColor: Color.black }]}>
+  <View style={styles.statusBar}>
     <StatusBar
       translucent
       backgroundColor={Color.black}
@@ -23,9 +23,9 @@ const GeneralStatusBar = () => (
 
 const RealTimeChess = () => {
   return (
-    <View style={{ flex: 1 }}>
+    <View style={styles.outerContainer}>
       <GeneralStatusBar />
-      <SafeAreaView style={{ flex: 1 }}>
+      <SafeAreaView style={styles.container}>
         <AppNavigatorContainer />
       </SafeAreaView>
     </View>
@@ -35,6 +35,14 @@ const RealTimeChess = () => {
 const styles = StyleSheet.create({
   statusBar: {
     height: Platform.OS === "ios" ? 20 : StatusBar.currentHeight,
+    backgroundColor: Color.black,
+  },
+  outerContainer: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: Color.black,
   },
 })
 


### PR DESCRIPTION
Why:
The SafeAreaView background color was white and visible on iPhone 11 and
11 max devices. By changing the color to black, it now blends in with
the rest of the screen.

This commit:
Adds a background color to SafeAreaView and sets it to black.

<img width="1358" alt="Screen Shot 2019-10-08 at 7 50 43 PM" src="https://user-images.githubusercontent.com/2924479/66441543-5d25b880-ea05-11e9-8a08-4dbac744299d.png">
