### PR TITLE
Select piece if own

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+
+.metals/

--- a/ios/RealTimeChess.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RealTimeChess.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/Game/GameContext.tsx
+++ b/src/Game/GameContext.tsx
@@ -117,25 +117,22 @@ const GameProvider = ({ children }: GameProviderProps) => {
     callBack: any
   ): void => {
     if (toTile === null) {
-      callBack(null)
       return
-    } else if (fromTile === null) {
-      const { rowIdx: toRow, colIdx: toCol } = toTile
-      const toPiece = board[toRow][toCol]
-      if (toPiece.isPiece) {
-        callBack({ rowIdx: toRow, colIdx: toCol })
-      }
-    } else if (
-      fromTile.rowIdx === toTile.rowIdx &&
-      fromTile.colIdx === toTile.colIdx
-    ) {
-      callBack(null)
-    } else {
-      if (GameHelpers.validMove(board, fromTile, toTile, side)) {
+    }
+
+    const toPiece = GameHelpers.getPiece(board, toTile)
+    if (fromTile === null && toPiece.isPiece) {
+      callBack(toTile)
+    } else if (fromTile !== null) {
+      const isMoveValid = GameHelpers.validMove(board, fromTile, toTile, side)
+
+      if (isMoveValid) {
         movePiece(fromTile, toTile)
         callBack(null)
       } else {
-        console.log("not a valid move: ", fromTile, toTile, side)
+        if (GameHelpers.getPiece(board, toTile).side === side) {
+          callBack(toTile)
+        }
       }
     }
   }

--- a/src/specs/Game/GameContext.spec.tsx
+++ b/src/specs/Game/GameContext.spec.tsx
@@ -1,0 +1,35 @@
+import React, { useContext } from "react"
+import { View, Text } from "react-native"
+import { render, cleanup } from "@testing-library/react-native"
+import "@testing-library/jest-native/extend-expect"
+
+import GameContext, { GameProvider } from "../../Game/GameContext"
+
+afterEach(cleanup)
+
+const renderGameProvider = () => {
+  const TestGameConsumer = () => {
+    const { userSelectedTile } = useContext(GameContext)
+    return (
+      <View>
+        <Text testID={"user-selected-tile"}>
+          {userSelectedTile || "no selection"}
+        </Text>
+      </View>
+    )
+  }
+
+  return render(
+    <GameProvider>
+      <TestGameConsumer />
+    </GameProvider>
+  )
+}
+
+describe("GameProvider", () => {
+  test("The GameScreen component provides the game context", () => {
+    const { getByTestId } = renderGameProvider()
+
+    expect(getByTestId("user-selected-tile")).toHaveTextContent("no selection")
+  })
+})


### PR DESCRIPTION
Why:
Currently, if a user has a piece selected and they select on of their
own pieces, nothing will happen. This is a confusing mechanic fro users.

This commit:
Changes the game behavior when selecting a piece. If a user has a piece
selected and their next selection is one of their own pieces, their
piece selection will change to the new piece.

Also .metals was added to .gitignore because vscode.

---

# After
![better-piece-selection-after](https://user-images.githubusercontent.com/16049495/66530098-55811500-ead4-11e9-9c81-ea67b000f4d1.gif)


# Before
![better-piece-selection-before](https://user-images.githubusercontent.com/16049495/66530105-5c0f8c80-ead4-11e9-82de-09cc84559210.gif)
