### PR TITLE
Computer deselects blank selection

### DIFF
--- a/src/Game/GameContext.tsx
+++ b/src/Game/GameContext.tsx
@@ -79,6 +79,7 @@ const GameProvider = ({ children }: GameProviderProps) => {
       return GameHelpers.squareToRCTile(computerCurrentMove.from)
     } else {
       setComputerCurrentMove(null)
+      setComputerSelectedTile(null)
       return GameHelpers.squareToRCTile(computerCurrentMove.to)
     }
   }


### PR DESCRIPTION
Why:
currently there is a bug where if a computer player ever ends up with
have a blank tile as its selection it will never select another piece.
This leads to an unsatisfying win.

This commit:
fixes the bug.

---

# gif

![computer deselects](https://user-images.githubusercontent.com/16049495/66531074-806d6800-ead8-11e9-81ba-cc2814770908.gif)
