### PR TITLE
Add rules for three kings version

### DIFF
--- a/src/Game/BoardRow.tsx
+++ b/src/Game/BoardRow.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { TouchableOpacity, View, StyleSheet } from "react-native"
 
 import Piece from "./Piece"
-import { PieceType } from "../utils/pieces"
+import { Piece as PieceType } from "../utils/chess/chess"
 import { BoardRow as BoardRowType, Tile } from "../utils/game_helpers"
 
 import { Colors } from "../styles"

--- a/src/Game/Classic/ClassicContext.tsx
+++ b/src/Game/Classic/ClassicContext.tsx
@@ -27,11 +27,11 @@ const ClassicContext = createContext<GameState>(initialGameState)
 
 const computerClockSpeed = 200
 
-interface GameProviderProps {
+interface ClassicProviderProps {
   children: JSX.Element
 }
 
-const ClassicProvider = ({ children }: GameProviderProps) => {
+const ClassicProvider = ({ children }: ClassicProviderProps) => {
   const { setCurrentWinner } = useContext(ArcadeContext)
 
   const [board, setBoard] = useState<GameHelpers.Board>(
@@ -144,19 +144,27 @@ const ClassicProvider = ({ children }: GameProviderProps) => {
     }
 
     const toPiece = GameHelpers.getPiece(board, toTile)
-    if (fromTile === null && toPiece.isPiece) {
+    const isSelectingAPiece = () => fromTile === null && toPiece.isPiece
+    const isSwitchingSelection = () =>
+      fromTile !== null && toPiece.side === side
+
+    if (isSelectingAPiece() || isSwitchingSelection()) {
       callBack(toTile)
     } else if (fromTile !== null) {
-      const isMoveValid = GameHelpers.validMove(board, fromTile, toTile, side)
+      handleAttack(board, fromTile, toTile, side)
+      callBack(null)
+    }
+  }
 
-      if (isMoveValid) {
-        movePiece(fromTile, toTile)
-        callBack(null)
-      } else {
-        if (GameHelpers.getPiece(board, toTile).side === side) {
-          callBack(toTile)
-        }
-      }
+  const handleAttack = (
+    board: GameHelpers.Board,
+    fromTile: GameHelpers.Tile,
+    toTile: GameHelpers.Tile,
+    side: Side
+  ): void => {
+    const isMoveValid = GameHelpers.validMove(board, fromTile, toTile, side)
+    if (isMoveValid) {
+      movePiece(fromTile, toTile)
     }
   }
 

--- a/src/Game/Piece.tsx
+++ b/src/Game/Piece.tsx
@@ -1,13 +1,12 @@
 import React from "react"
 import { View, StyleSheet, Image, ImageSourcePropType } from "react-native"
 
-import { FenId } from "../utils/chess/types"
-import { Pieces } from "../utils"
+import { Piece as PieceType, FenId } from "../utils/chess/chess"
 
 import { Images } from "../assets"
 
 interface PieceProps {
-  piece: Pieces.PieceInterface
+  piece: PieceType
   testID?: string
 }
 
@@ -19,7 +18,7 @@ const Piece = ({ piece, testID }: PieceProps) => (
 
 type PieceFlags = { [P in FenId]: ImageSourcePropType }
 
-const pieceImageSource = (piece: Pieces.PieceType): ImageSourcePropType => {
+const pieceImageSource = (piece: PieceType): ImageSourcePropType => {
   const styleMap: PieceFlags = {
     "0": Images.BlackPawn,
     r: Images.BlackRook,

--- a/src/Game/ThreeKings/index.tsx
+++ b/src/Game/ThreeKings/index.tsx
@@ -12,16 +12,24 @@ const ThreeKingsGame = () => {
     countdownCount,
     userSelectedTile,
     computerSelectedTile,
+    userLives,
+    computerLives,
     selectUserTile,
   } = useContext(ThreeKingsContext)
   return (
-    <Board
-      board={board}
-      countdownCount={countdownCount}
-      userSelectedTile={userSelectedTile}
-      computerSelectedTile={computerSelectedTile}
-      selectUserTile={selectUserTile}
-    />
+    <View>
+      <View>
+        <Text style={Typography.header}>userLives: {userLives}</Text>
+        <Text style={Typography.header}>computerLives: {computerLives}</Text>
+      </View>
+      <Board
+        board={board}
+        countdownCount={countdownCount}
+        userSelectedTile={userSelectedTile}
+        computerSelectedTile={computerSelectedTile}
+        selectUserTile={selectUserTile}
+      />
+    </View>
   )
 }
 

--- a/src/utils/chess/chess.ts
+++ b/src/utils/chess/chess.ts
@@ -398,7 +398,7 @@ const Chess = (fen: string = DEFAULT_POSITION): ChessInstance => {
     return [fen, turn, cflags, epflags, half_moves, move_number].join(" ")
   }
 
-  function put(piece: Piece, square: Square) {
+  function put(piece: InternalPiece, square: Square) {
     /* check for valid piece object */
     if (!("type" in piece && "color" in piece)) {
       return false

--- a/src/utils/chess/types.ts
+++ b/src/utils/chess/types.ts
@@ -8,6 +8,29 @@ export type Side = "b" | "w"
 export const black: Side = "b"
 export const white: Side = "w"
 
+export interface Piece {
+  kind: string
+  /**
+   * The type of the piece to place
+   * - "p" for Pawn
+   * - "n" for Knight
+   * - "b" for Bishop
+   * - "r" for Rook
+   * - "q" for Queen
+   * - "k" for King
+   */
+  type: PieceType
+  side?: Side
+  /**
+   * The color of the piece
+   * - "b" for Black
+   * - "w" for White
+   */
+  color: Side
+  isPiece: boolean
+  fenId: FenId
+}
+
 /**
  * tuple of a parsed fen code
  * rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
@@ -140,26 +163,6 @@ export type InternalPiece = {
 }
 
 export type InternalBoard = (InternalPiece | null)[]
-
-export interface Piece {
-  /**
-   * The type of the piece to place
-   * - "p" for Pawn
-   * - "n" for Knight
-   * - "b" for Bishop
-   * - "r" for Rook
-   * - "q" for Queen
-   * - "k" for King
-   */
-  type: PieceType
-
-  /**
-   * The color of the piece
-   * - "b" for Black
-   * - "w" for White
-   */
-  color: Side
-}
 
 export interface ChessInstance {
   /**

--- a/src/utils/game_helpers.spec.ts
+++ b/src/utils/game_helpers.spec.ts
@@ -11,6 +11,7 @@ import {
   boardToAscii,
   updateBoard,
   updateBoardWithMove,
+  removePiece,
 } from "./game_helpers"
 import { BoardFixtures } from "../__fixtures__"
 
@@ -425,6 +426,18 @@ describe("updateBoard", () => {
         expectBoardsToMatch(result, expected)
       })
     })
+  })
+})
+
+describe("removePiece", () => {
+  test("it returns a new board without the piece", () => {
+    const startBoard: Board = createBoard()
+
+    const result: Board = removePiece(startBoard, { rowIdx: 0, colIdx: 2 })
+
+    const expectedFen = "rn1qkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR KQkq - 0 1"
+    const expected: Board = createBoard(expectedFen)
+    expectBoardsToMatch(result, expected)
   })
 })
 

--- a/src/utils/game_helpers.ts
+++ b/src/utils/game_helpers.ts
@@ -2,6 +2,7 @@ import {
   ChessInstance,
   ShortMove,
   Square,
+  Piece,
   Move,
   Side,
   black,
@@ -9,19 +10,10 @@ import {
 } from "../utils/chess/chess"
 
 import Chess from "./chess/chess"
-import {
-  PieceType,
-  empty,
-  pawn,
-  knight,
-  bishop,
-  rook,
-  queen,
-  king,
-} from "./pieces"
+import { empty, pawn, knight, bishop, rook, queen, king } from "./pieces"
 import * as ArrayHelpers from "./array_helpers"
 
-export type BoardRow = PieceType[]
+export type BoardRow = Piece[]
 export type Board = BoardRow[]
 
 export interface Tile {
@@ -37,7 +29,7 @@ export interface ANTile {
 
 interface PieceWithTile {
   tile: Tile
-  piece: PieceType
+  piece: Piece
 }
 
 const FileToCol: { [key: string]: number } = {
@@ -74,17 +66,17 @@ export const createBoard = (fenCode: string = initialBoardFenCode): Board => {
   })
 }
 
-function fenCharToPieceSubArray(char: string): PieceType[] {
+function fenCharToPieceSubArray(char: string): BoardRow {
   if (isNaN(Number(char))) {
     return [createPieceByFenCode(char)]
   } else {
-    return Array<PieceType>(Number(char)).fill(new empty())
+    return Array<Piece>(Number(char)).fill(new empty())
   }
 }
 
 export const initialBoard = createBoard(initialBoardFenCode)
 
-function createPieceByFenCode(fenCode: string): PieceType {
+function createPieceByFenCode(fenCode: string): Piece {
   switch (fenCode) {
     case "r": {
       return new rook(black)
@@ -132,10 +124,10 @@ export const winner = (board: Board): Side | null => {
   const kingColors: Array<Side | undefined> = board.flatMap(
     (rank: BoardRow) => {
       return rank
-        .filter((piece: PieceType) => {
+        .filter((piece: Piece) => {
           return piece.kind === "king"
         })
-        .map((piece: PieceType) => {
+        .map((piece: Piece) => {
           return piece.side
         })
     }
@@ -179,10 +171,7 @@ export const squareToRCTile = (square: Square): Tile => {
   }
 }
 
-export function playerPieces(
-  board: PieceType[][],
-  side: Side
-): PieceWithTile[] {
+export function playerPieces(board: Board, side: Side): PieceWithTile[] {
   const pieces = []
   for (let i = 0; i < 8; i++) {
     for (let j = 0; j < 8; j++) {
@@ -197,7 +186,7 @@ export function playerPieces(
   return pieces
 }
 
-export function getPiece(board: Board, tile: Tile): PieceType {
+export function getPiece(board: Board, tile: Tile): Piece {
   return board[tile.rowIdx][tile.colIdx]
 }
 
@@ -292,6 +281,13 @@ export function updateBoard(
   } else {
     return oldBoard
   }
+}
+
+export function removePiece(oldBoard: Board, tile: Tile): Board {
+  const { colIdx, rowIdx } = tile
+  const newBoard = ArrayHelpers.deepDup(oldBoard)
+  newBoard[rowIdx][colIdx] = new empty()
+  return newBoard
 }
 
 export function validMove(

--- a/src/utils/pieces.ts
+++ b/src/utils/pieces.ts
@@ -1,11 +1,4 @@
-import { FenId, Side, black } from "./chess/chess"
-
-interface Piece {
-  kind: string
-  side?: Side
-  isPiece: boolean
-  fenId: FenId
-}
+import { Side, Piece, black } from "./chess/chess"
 
 interface Empty extends Piece {}
 interface Pawn extends Piece {}
@@ -14,8 +7,6 @@ interface Bishop extends Piece {}
 interface Rook extends Piece {}
 interface Queen extends Piece {}
 interface King extends Piece {}
-
-type PieceType = Empty | Pawn | Knight | Bishop | Rook | Queen | King
 
 const empty = (function empty(this: Empty) {
   this.kind = "empty"
@@ -69,7 +60,6 @@ const king = (function king(this: King, side: Side) {
 export { empty, pawn, knight, bishop, rook, queen, king }
 export {
   Piece as PieceInterface,
-  PieceType,
   Empty,
   Pawn,
   Knight,


### PR DESCRIPTION
Why:
We would like to be able to play test the version of the game with the
rule of a player must take the opponents king three times to win.

This commit:
Updates the ThreeKingsContext to enforce this new rule. Additionally The
Piece interface definition was consolidated to be only in the
chess/types.ts file and not in both types.ts and pieces.ts.

---

# gif:
![three-kings](https://user-images.githubusercontent.com/16049495/67622673-6e830900-f7ea-11e9-81d1-e3bc99cca450.gif)
