### PR TITLE
Ais only select pieces without a cooldown

### DIFF
--- a/src/Game/game_hooks.ts
+++ b/src/Game/game_hooks.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useContext } from "react"
 
 import ArcadeContext from "../ArcadeContext"
-import { MinimaxAI } from "../utils/ai"
+import { MaximizingAI } from "../utils/ai"
 import { GameHelpers } from "../utils"
 import { Board, Tile } from "../utils/game_helpers"
 import { Move, Side, black, white } from "../utils/chess/chess"
@@ -86,7 +86,7 @@ export const useGameState = (
 
   const getNextComputerTile = (): Tile | null => {
     if (computerCurrentMove == null) {
-      const move = MinimaxAI.selectMove(board, black)
+      const move = MaximizingAI.selectMove(board, black)
       if (move == null) {
         return null
       }

--- a/src/utils/ai/ai_helpers.spec.ts
+++ b/src/utils/ai/ai_helpers.spec.ts
@@ -1,0 +1,82 @@
+import {
+  Square,
+  Move,
+  PieceType,
+  Side,
+  black,
+  white,
+  Promotion,
+} from "../chess/chess"
+import { Board, createBoard } from "../game_helpers"
+
+import { validMoves } from "./ai_helpers"
+
+describe("validMoves", () => {
+  describe("when the current player is white", () => {
+    test("it returns all valid moves for the white player", () => {
+      const fenCodeWithOnePiece = "4q3/8/8/8/8/8/P7/RK6 b KQkq - 0 1"
+      const board: Board = createBoard(fenCodeWithOnePiece)
+
+      const moves: Move[] = validMoves(board, white)
+
+      expect(moves).toEqual([
+        move("w", "a2", "a3", "n", "p", "a3"),
+        move("w", "a2", "a4", "b", "p", "a4"),
+        move("w", "b1", "b2", "n", "k", "Kb2"),
+        move("w", "b1", "c2", "n", "k", "Kc2"),
+        move("w", "b1", "c1", "n", "k", "Kc1"),
+        move("w", "b1", "d1", "k", "k", "O-O"),
+      ])
+    })
+  })
+
+  describe("when either player has lost their king", () => {
+    test("it returns []", () => {
+      const fenCodeWithNoKings =
+        "rbnq1nbr/pppppppp/8/8/8/8/PPPPPPPP/RBNQ1NBR b - - 0 1"
+      const board: Board = createBoard(fenCodeWithNoKings)
+
+      const moves: Move[] = validMoves(board, black)
+
+      expect(moves).toEqual([])
+    })
+  })
+
+  describe("when there are pieces with active cooldowns", () => {
+    test("it doens't include any piece with an acitve cooldown", () => {
+      const fenCodeWithOnePiece = "4q3/8/8/8/8/8/P7/RK6 b KQkq - 0 1"
+      const board: Board = createBoard(fenCodeWithOnePiece)
+      const king = board[7][1]
+      king.cooldown = 3
+
+      const moves: Move[] = validMoves(board, white)
+
+      expect(moves).toEqual([
+        move("w", "a2", "a3", "n", "p", "a3"),
+        move("w", "a2", "a4", "b", "p", "a4"),
+      ])
+    })
+  })
+})
+
+const move = (
+  side: Side,
+  from: Square,
+  to: Square,
+  flags: string,
+  piece: PieceType,
+  san: string,
+  captured?: PieceType,
+  promotion?: Promotion
+): Move => {
+  return {
+    color: side,
+    from,
+    to,
+    flags,
+    piece,
+    san,
+    captured,
+    promotion,
+  }
+}

--- a/src/utils/ai/ai_helpers.ts
+++ b/src/utils/ai/ai_helpers.ts
@@ -1,0 +1,18 @@
+import Chess, { Side, Move, ChessInstance } from "../chess/chess"
+import { Board, generateFen, squareToRCTile } from "../game_helpers"
+
+export function validMoves(board: Board, side: Side): Move[] {
+  const fen = generateFen(board, side)
+  const chessInstance: ChessInstance = Chess(fen)
+  try {
+    const allMoves = chessInstance.moves()
+    return allMoves.filter((move: Move) => {
+      const { colIdx, rowIdx } = squareToRCTile(move.from)
+      const piece = board[rowIdx][colIdx]
+      return !(piece.cooldown > 0)
+    })
+  } catch (e) {
+    console.log("chess instance errored looking for moves for: ", fen)
+    return []
+  }
+}

--- a/src/utils/ai/index.ts
+++ b/src/utils/ai/index.ts
@@ -1,4 +1,4 @@
 import * as RandomAI from "./random_ai"
-import * as MinimaxAI from "./maximizing_ai"
+import * as MaximizingAI from "./maximizing_ai"
 
-export { RandomAI, MinimaxAI }
+export { RandomAI, MaximizingAI }

--- a/src/utils/ai/maximizing_ai.ts
+++ b/src/utils/ai/maximizing_ai.ts
@@ -1,7 +1,8 @@
-import Chess, { ChessInstance, Move, Side, black } from "../chess/chess"
+import { Move, Side, black } from "../chess/chess"
 import { FenId } from "../chess/types"
-import { Board, generateFen, updateBoardWithMove } from "../game_helpers"
+import { Board, updateBoardWithMove } from "../game_helpers"
 import * as ArrayHelpers from "../array_helpers"
+import { validMoves } from "./ai_helpers"
 
 interface MoveWithValue {
   move: Move
@@ -172,12 +173,6 @@ export function boardValue(board: Board): number {
   return values.reduce((acc, pieceValue, _index) => {
     return pieceValue + acc
   })
-}
-
-function validMoves(board: Board, side: Side): Move[] {
-  const fen = generateFen(board, side)
-  const chessInstance: ChessInstance = Chess(fen)
-  return chessInstance.moves()
 }
 
 const pieceValues: { [id in FenId]: number } = {

--- a/src/utils/ai/random_ai.spec.ts
+++ b/src/utils/ai/random_ai.spec.ts
@@ -1,8 +1,7 @@
-import { Square, Move, PieceType, Side, black, white } from "../chess/chess"
+import { Square, Move, PieceType, Side, white, Promotion } from "../chess/chess"
 import { Board, createBoard } from "../game_helpers"
-import { Promotion } from "../chess/types"
 
-import { validMoves, selectMove } from "./random_ai"
+import { selectMove } from "./random_ai"
 
 describe("selectMove", () => {
   describe("when there is are valid attacking moves", () => {
@@ -42,38 +41,6 @@ describe("selectMove", () => {
       const result = selectMove(board, white)
 
       expect(result).toBe(null)
-    })
-  })
-})
-
-describe("validMoves", () => {
-  describe("when the current player is white", () => {
-    test("it returns all valid moves for the white player", () => {
-      const fenCodeWithOnePiece = "4q3/8/8/8/8/8/P7/RK6 b KQkq - 0 1"
-      const board: Board = createBoard(fenCodeWithOnePiece)
-
-      const moves: Move[] = validMoves(board, white)
-
-      expect(moves).toEqual([
-        move("w", "a2", "a3", "n", "p", "a3"),
-        move("w", "a2", "a4", "b", "p", "a4"),
-        move("w", "b1", "b2", "n", "k", "Kb2"),
-        move("w", "b1", "c2", "n", "k", "Kc2"),
-        move("w", "b1", "c1", "n", "k", "Kc1"),
-        move("w", "b1", "d1", "k", "k", "O-O"),
-      ])
-    })
-  })
-
-  describe("when either player has lost their king", () => {
-    test("it returns []", () => {
-      const fenCodeWithNoKings =
-        "rbnq1nbr/pppppppp/8/8/8/8/PPPPPPPP/RBNQ1NBR b - - 0 1"
-      const board: Board = createBoard(fenCodeWithNoKings)
-
-      const moves: Move[] = validMoves(board, black)
-
-      expect(moves).toEqual([])
     })
   })
 })

--- a/src/utils/ai/random_ai.ts
+++ b/src/utils/ai/random_ai.ts
@@ -1,6 +1,7 @@
-import Chess, { ChessInstance, Move, Side } from "../chess/chess"
-import { Board, generateFen, squareToRCTile, getPiece } from "../game_helpers"
+import { Move, Side } from "../chess/chess"
+import { Board, squareToRCTile, getPiece } from "../game_helpers"
 import { sample } from "../array_helpers"
+import { validMoves } from "./ai_helpers"
 
 export const selectMove = (board: Board, side: Side): Move | null => {
   const moves: Move[] = validMoves(board, side)
@@ -22,16 +23,5 @@ export const selectMove = (board: Board, side: Side): Move | null => {
     return sample<Move>(attackingMoves)
   } else {
     return sample<Move>(moves)
-  }
-}
-
-export function validMoves(board: Board, side: Side): Move[] {
-  const fen = generateFen(board, side)
-  const chessInstance: ChessInstance = Chess(fen)
-  try {
-    return chessInstance.moves()
-  } catch (e) {
-    console.log("chess instance errored looking for moves for: ", fen)
-    return []
   }
 }

--- a/src/utils/chess/chess.ts
+++ b/src/utils/chess/chess.ts
@@ -1053,5 +1053,6 @@ export {
   FenId,
   black,
   white,
+  Promotion,
 }
 export default Chess

--- a/src/utils/chess/types.ts
+++ b/src/utils/chess/types.ts
@@ -15,7 +15,7 @@ export interface Empty {
   side: null
   fenId: null
   color: null
-  cooldown?: null
+  cooldown: 0
 }
 
 export interface Piece {
@@ -39,7 +39,7 @@ export interface Piece {
   color: Side
   isPiece: boolean
   fenId: FenId
-  cooldown?: number
+  cooldown: number
 }
 
 /**


### PR DESCRIPTION
Why:
Currently the computer players will select pieces to move that have an
active cooldown. This is somewhat distracting to a player and leads to a
less challenging ai.

This commit:
Adds a filtering step in the ai validMoves function to remove all from
pieces that have an active cooldown. Note that this will be run even in
games that don't have the cooldown mechanic. It's possible to separate
this logic out and compose which rules the ai needs to be aware of.
While cleaner, this would certainly be a neglible performace
impromvement so we are not implementing it in this commit for sake of
time.