### PR TITLE
Add playground mode

### DIFF
--- a/src/Arcade.spec.tsx
+++ b/src/Arcade.spec.tsx
@@ -2,7 +2,12 @@ import React from "react"
 import { render, cleanup, wait } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 
-import ArcadeContext, { ArcadeState, initialArcadeState } from "./ArcadeContext"
+import ArcadeContext, {
+  ArcadeState,
+  initialArcadeState,
+  Games,
+  Screens,
+} from "./ArcadeContext"
 import ArcadeScreen from "./Arcade"
 
 afterEach(cleanup)
@@ -26,16 +31,16 @@ describe("Aracade", () => {
     describe("and when black has won the game", () => {
       test("a 'You Lose' message is visable", async () => {
         const arcadeState: ArcadeState = {
-          currentGame: "Classic",
+          currentGame: Games.Classic,
           currentWinner: "b",
           computerClockSpeed: 200,
           gameIsActive: true,
-          onLanding: false,
+          currentScreen: Screens.Game,
           setCurrentGame: () => {},
           setCurrentWinner: () => {},
           setComputerClockSpeed: () => {},
           setGameIsActive: () => {},
-          goToGame: () => {},
+          setCurrentScreen: () => {},
         }
         const { queryByTestId } = renderGameScreen(arcadeState)
 
@@ -49,16 +54,16 @@ describe("Aracade", () => {
     describe("and when white has won the game", () => {
       test("a 'You Won' message is visable", async () => {
         const arcadeState: ArcadeState = {
-          currentGame: "Classic",
+          currentGame: Games.Classic,
           currentWinner: "w",
           computerClockSpeed: 200,
           gameIsActive: true,
-          onLanding: false,
+          currentScreen: Screens.Game,
           setCurrentGame: () => {},
           setCurrentWinner: () => {},
           setComputerClockSpeed: () => {},
           setGameIsActive: () => {},
-          goToGame: () => {},
+          setCurrentScreen: () => {},
         }
         const { queryByTestId } = renderGameScreen(arcadeState)
 

--- a/src/Arcade.tsx
+++ b/src/Arcade.tsx
@@ -1,23 +1,25 @@
 import React, { useContext } from "react"
 import { View, StyleSheet } from "react-native"
 
-import ArcadeContext from "./ArcadeContext"
+import ArcadeContext, { Screens } from "./ArcadeContext"
 import LandingScreen from "./Landing"
 import GameScreen from "./Game"
 import GameOverScreen from "./GameOver"
 
 const Arcade = () => {
-  const { currentWinner, onLanding } = useContext(ArcadeContext)
+  const { currentWinner, currentScreen } = useContext(ArcadeContext)
 
   const chooseScreen = () => {
-    if (onLanding) {
-      return <LandingScreen />
-    } else if (currentWinner == null) {
-      return <GameScreen />
-    } else if (currentWinner != null) {
-      return <GameOverScreen />
-    } else {
-      throw new Error("Invalid Aracade Context State")
+    switch (currentScreen) {
+      case Screens.Landing: {
+        return <LandingScreen />
+      }
+      case Screens.Game: {
+        return currentWinner == null ? <GameScreen /> : <GameOverScreen />
+      }
+      default: {
+        return <LandingScreen />
+      }
     }
   }
 

--- a/src/ArcadeContext.tsx
+++ b/src/ArcadeContext.tsx
@@ -1,12 +1,20 @@
 import React, { createContext, useState } from "react"
 
 import { Side } from "./utils/chess/types"
-export type Game = "Classic" | "ThreeKings" | "Cooldown"
+export type Game = "Classic" | "ThreeKings" | "Cooldown" | "Playground"
 
 export const Games: { [k in Game]: Game } = {
   Classic: "Classic",
   ThreeKings: "ThreeKings",
   Cooldown: "Cooldown",
+  Playground: "Playground",
+}
+
+export type Screen = "Landing" | "Game"
+
+export const Screens: { [screen in Screen]: Screen } = {
+  Landing: "Landing",
+  Game: "Game",
 }
 
 export interface ArcadeState {
@@ -14,25 +22,25 @@ export interface ArcadeState {
   currentWinner: Side | null
   computerClockSpeed: number
   gameIsActive: boolean
-  onLanding: boolean
+  currentScreen: Screen
   setCurrentGame: (game: Game) => void
   setCurrentWinner: (side: Side | null) => void
   setComputerClockSpeed: (speed: number) => void
   setGameIsActive: (state: boolean) => void
-  goToGame: () => void
+  setCurrentScreen: (screen: Screen) => void
 }
 
 export const initialArcadeState = {
-  currentGame: "Classic" as Game,
+  currentGame: Games.Classic,
   currentWinner: null,
-  computerClockSpeed: 600,
+  computerClockSpeed: 1000,
   gameIsActive: false,
-  onLanding: true,
+  currentScreen: Screens.Landing,
   setCurrentGame: () => {},
   setCurrentWinner: () => {},
   setGameIsActive: () => {},
   setComputerClockSpeed: () => {},
-  goToGame: () => {},
+  setCurrentScreen: () => {},
 }
 
 const ArcadeContext = createContext<ArcadeState>(initialArcadeState)
@@ -54,13 +62,9 @@ const ArcadeProvider = ({ children }: GameProviderProps) => {
   const [gameIsActive, setGameIsActive] = useState<boolean>(
     initialArcadeState.gameIsActive
   )
-  const [onLanding, setOnLanding] = useState<boolean>(
-    initialArcadeState.onLanding
+  const [currentScreen, setCurrentScreen] = useState<Screen>(
+    initialArcadeState.currentScreen
   )
-
-  const goToGame = () => {
-    setOnLanding(false)
-  }
 
   return (
     <ArcadeContext.Provider
@@ -69,12 +73,12 @@ const ArcadeProvider = ({ children }: GameProviderProps) => {
         currentWinner,
         computerClockSpeed,
         gameIsActive,
-        onLanding,
+        currentScreen,
         setCurrentGame,
         setCurrentWinner,
         setComputerClockSpeed,
         setGameIsActive,
-        goToGame,
+        setCurrentScreen,
       }}
     >
       {children}

--- a/src/Game/Board.tsx
+++ b/src/Game/Board.tsx
@@ -3,13 +3,11 @@ import { View, StyleSheet } from "react-native"
 
 import { Board as BoardType, Tile } from "../utils/game_helpers"
 import BoardRow from "./BoardRow"
-import Countdown from "./Countdown"
 
 import { Layout } from "../styles"
 
 interface BoardProps {
   board: BoardType
-  countdownCount: number
   userSelectedTile: Tile | null
   computerSelectedTile: Tile | null
   selectUserTile: (tile: Tile) => void
@@ -17,14 +15,12 @@ interface BoardProps {
 
 const Board = ({
   board,
-  countdownCount,
   userSelectedTile,
   computerSelectedTile,
   selectUserTile,
 }: BoardProps) => {
   return (
     <View style={styles.container}>
-      {countdownCount >= 0 ? <Countdown count={countdownCount} /> : null}
       {board.map((row, rowIdx) => {
         return (
           <View style={styles.row} key={`row-${rowIdx}`}>

--- a/src/Game/Classic/ClassicContext.tsx
+++ b/src/Game/Classic/ClassicContext.tsx
@@ -3,18 +3,16 @@ import React, { createContext } from "react"
 import { GameHelpers } from "../../utils"
 import { Side } from "../../utils/chess/chess"
 import { Board, Tile } from "../../utils/game_helpers"
-import { GameState, useGameState } from "../game_hooks"
+import {
+  GameStateWithCountdown,
+  initialGameStateWithCountdown,
+  useGameState,
+  useCountDown,
+} from "../game_hooks"
 
-export const initialGameState: GameState = {
-  board: GameHelpers.createBoard(),
-  userSelectedTile: null,
-  computerSelectedTile: null,
-  countdownCount: 3,
-  resetBoard: () => {},
-  selectUserTile: () => {},
-}
-
-const ClassicContext = createContext<GameState>(initialGameState)
+const ClassicContext = createContext<GameStateWithCountdown>(
+  initialGameStateWithCountdown
+)
 
 interface ClassicProviderProps {
   children: JSX.Element
@@ -43,10 +41,11 @@ const ClassicProvider = ({ children }: ClassicProviderProps) => {
     setBoard,
     userSelectedTile,
     computerSelectedTile,
-    countdownCount,
     selectUserTile,
     resetBoard,
-  } = useGameState(handleAttack)
+    setGameIsActive,
+  } = useGameState({ handleAttack })
+  const { countdownCount } = useCountDown(3, () => setGameIsActive(true))
 
   return (
     <ClassicContext.Provider

--- a/src/Game/Classic/index.tsx
+++ b/src/Game/Classic/index.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from "react"
+import { View } from "react-native"
 
 import Board from "../Board"
-import ClassicContext, { ClassicProvider } from "./ClassicContext"
 import GameContainer from "../GameContainer"
+import Countdown from "../Countdown"
+import ClassicContext, { ClassicProvider } from "./ClassicContext"
 
 const ClassicGame = () => {
   const {
@@ -13,13 +15,15 @@ const ClassicGame = () => {
     selectUserTile,
   } = useContext(ClassicContext)
   return (
-    <Board
-      board={board}
-      countdownCount={countdownCount}
-      userSelectedTile={userSelectedTile}
-      computerSelectedTile={computerSelectedTile}
-      selectUserTile={selectUserTile}
-    />
+    <View>
+      {countdownCount >= 0 ? <Countdown count={countdownCount} /> : null}
+      <Board
+        board={board}
+        userSelectedTile={userSelectedTile}
+        computerSelectedTile={computerSelectedTile}
+        selectUserTile={selectUserTile}
+      />
+    </View>
   )
 }
 

--- a/src/Game/Cooldown/CooldownContext.tsx
+++ b/src/Game/Cooldown/CooldownContext.tsx
@@ -4,18 +4,16 @@ import { GameHelpers } from "../../utils"
 import { Piece, Side } from "../../utils/chess/chess"
 import { Board, Tile } from "../../utils/game_helpers"
 
-import { useGameState, GameState } from "../game_hooks"
+import {
+  useGameState,
+  GameStateWithCountdown,
+  initialGameStateWithCountdown,
+  useCountDown,
+} from "../game_hooks"
 
-const initialGameState: GameState = {
-  board: GameHelpers.createBoard(),
-  userSelectedTile: null,
-  computerSelectedTile: null,
-  countdownCount: 3,
-  resetBoard: () => {},
-  selectUserTile: () => {},
-}
-
-const CooldownContext = createContext<GameState>(initialGameState)
+const CooldownContext = createContext<GameStateWithCountdown>(
+  initialGameStateWithCountdown
+)
 
 interface CooldownProviderProps {
   children: JSX.Element
@@ -68,10 +66,11 @@ const CooldownProvider = ({ children }: CooldownProviderProps) => {
     setBoard,
     userSelectedTile,
     computerSelectedTile,
-    countdownCount,
     selectUserTile,
     resetBoard,
-  } = useGameState(handleAttack, decrementCooldowns)
+    setGameIsActive,
+  } = useGameState({ handleAttack, decrementCooldowns })
+  const { countdownCount } = useCountDown(3, () => setGameIsActive(true))
 
   return (
     <CooldownContext.Provider

--- a/src/Game/Playground/PlaygroundContext.tsx
+++ b/src/Game/Playground/PlaygroundContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext } from "react"
+
+import { GameHelpers } from "../../utils"
+import { Board, Tile } from "../../utils/game_helpers"
+import { GameState, initialGameState, useGameState } from "../game_hooks"
+
+const PlaygroundContext = createContext<GameState>(initialGameState)
+
+interface PlaygroundProviderProps {
+  children: JSX.Element
+}
+
+const PlaygroundProvider = ({ children }: PlaygroundProviderProps) => {
+  const handleAttack = (board: Board, fromTile: Tile, toTile: Tile): void => {
+    const movePiece = (fromTile: Tile, toTile: Tile): void => {
+      const newBoard = GameHelpers.updateBoard(board, fromTile, toTile)
+      setBoard(newBoard)
+    }
+    movePiece(fromTile, toTile)
+  }
+
+  const {
+    board,
+    setBoard,
+    userSelectedTile,
+    computerSelectedTile,
+    selectUserTile,
+    resetBoard,
+  } = useGameState({ handleAttack, tick: () => {} })
+
+  return (
+    <PlaygroundContext.Provider
+      value={{
+        board,
+        userSelectedTile,
+        computerSelectedTile,
+        resetBoard: resetBoard,
+        selectUserTile: selectUserTile,
+      }}
+    >
+      {children}
+    </PlaygroundContext.Provider>
+  )
+}
+
+export { PlaygroundProvider }
+export default PlaygroundContext

--- a/src/Game/Playground/index.tsx
+++ b/src/Game/Playground/index.tsx
@@ -2,21 +2,19 @@ import React, { useContext } from "react"
 import { View } from "react-native"
 
 import Board from "../Board"
-import Countdown from "../Countdown"
 import GameContainer from "../GameContainer"
-import CooldownContext, { CooldownProvider } from "./CooldownContext"
+import PlaygroundContext, { PlaygroundProvider } from "./PlaygroundContext"
 
-const CooldownGame = () => {
+const PlaygroundGame = () => {
   const {
     board,
-    countdownCount,
     userSelectedTile,
     computerSelectedTile,
     selectUserTile,
-  } = useContext(CooldownContext)
+  } = useContext(PlaygroundContext)
+
   return (
     <View>
-      {countdownCount >= 0 ? <Countdown count={countdownCount} /> : null}
       <Board
         board={board}
         userSelectedTile={userSelectedTile}
@@ -27,14 +25,14 @@ const CooldownGame = () => {
   )
 }
 
-const Cooldown = () => {
+const ThreeKings = () => {
   return (
-    <CooldownProvider>
-      <GameContainer title={"Cooldown"}>
-        <CooldownGame />
+    <PlaygroundProvider>
+      <GameContainer title={"Playground"}>
+        <PlaygroundGame />
       </GameContainer>
-    </CooldownProvider>
+    </PlaygroundProvider>
   )
 }
 
-export default Cooldown
+export default ThreeKings

--- a/src/Game/Settings.tsx
+++ b/src/Game/Settings.tsx
@@ -1,36 +1,53 @@
 import React, { useContext } from "react"
-import { View, Text, StyleSheet } from "react-native"
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native"
 import Slider from "@react-native-community/slider"
 
-import ArcadeContext from "../ArcadeContext"
+import ArcadeContext, { Screens } from "../ArcadeContext"
 
-import { Typography } from "../styles"
+import { Typography, Buttons } from "../styles"
 
 const Settings = () => {
-  const { setComputerClockSpeed, computerClockSpeed } = useContext(
-    ArcadeContext
-  )
+  const {
+    setComputerClockSpeed,
+    computerClockSpeed,
+    setCurrentScreen,
+    setGameIsActive,
+  } = useContext(ArcadeContext)
 
   const handleOnValueChange = (value: number) => {
     setComputerClockSpeed(1100 - value * 100)
   }
-
   const sliderValue = (1100 - computerClockSpeed) / 100
+
+  const handleOnPressMainMenu = () => {
+    setCurrentScreen(Screens.Landing)
+    setGameIsActive(false)
+  }
 
   return (
     <View style={styles.container}>
       <Text style={styles.settingsText}>Settings</Text>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputText}>AI Speed</Text>
-        <Slider
-          style={styles.slider}
-          minimumValue={1}
-          maximumValue={10}
-          step={1}
-          value={sliderValue}
-          onValueChange={(value: number) => handleOnValueChange(value)}
-        />
-        <Text style={styles.inputText}>{sliderValue}</Text>
+      <View style={styles.inputsContainer}>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputText}>AI Speed</Text>
+          <Slider
+            style={styles.slider}
+            minimumValue={1}
+            maximumValue={10}
+            step={1}
+            value={sliderValue}
+            onValueChange={(value: number) => handleOnValueChange(value)}
+          />
+          <Text style={styles.inputText}>{sliderValue}</Text>
+        </View>
+        <View style={styles.inputContainer}>
+          <TouchableOpacity
+            onPress={handleOnPressMainMenu}
+            style={styles.quitButton}
+          >
+            <Text style={styles.quitText}>Go To Main Menu</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   )
@@ -43,16 +60,28 @@ const styles = StyleSheet.create({
   settingsText: {
     ...Typography.darkHeader,
   },
-  inputContainer: {
-    flexDirection: "row",
+  inputsContainer: {
     justifyContent: "space-between",
     alignItems: "center",
+  },
+  inputContainer: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+    width: "100%",
+    paddingVertical: 10,
   },
   inputText: {
     ...Typography.label,
   },
   slider: {
     width: "60%",
+  },
+  quitButton: {
+    ...Buttons.smallSquareRed,
+  },
+  quitText: {
+    ...Typography.smallWhiteBold,
   },
 })
 

--- a/src/Game/ThreeKings/ThreeKingsContext.tsx
+++ b/src/Game/ThreeKings/ThreeKingsContext.tsx
@@ -1,27 +1,29 @@
 import React, { createContext, useState } from "react"
 
-import { useGameState, GameState } from "../game_hooks"
 import { GameHelpers } from "../../utils"
 import { Side } from "../../utils/chess/chess"
 import { Tile, Board } from "../../utils/game_helpers"
+import {
+  useGameState,
+  GameStateWithCountdown,
+  initialGameStateWithCountdown,
+  useCountDown,
+} from "../game_hooks"
 
-export interface ThreeKingsGameState extends GameState {
+export interface ThreeKingsGameState extends GameStateWithCountdown {
   userLives: number
   computerLives: number
 }
 
-export const initialGameState: ThreeKingsGameState = {
-  board: GameHelpers.createBoard(),
-  userSelectedTile: null,
-  computerSelectedTile: null,
-  countdownCount: 3,
+export const initialThreeKingsGameState: ThreeKingsGameState = {
+  ...initialGameStateWithCountdown,
   userLives: 3,
   computerLives: 3,
-  resetBoard: () => {},
-  selectUserTile: () => {},
 }
 
-const ThreeKingsContext = createContext<ThreeKingsGameState>(initialGameState)
+const ThreeKingsContext = createContext<ThreeKingsGameState>(
+  initialThreeKingsGameState
+)
 
 interface ThreeKingsProviderProps {
   children: JSX.Element
@@ -77,10 +79,11 @@ const ThreeKingsProvider = ({ children }: ThreeKingsProviderProps) => {
     setBoard,
     userSelectedTile,
     computerSelectedTile,
-    countdownCount,
     selectUserTile,
     resetBoard,
-  } = useGameState(handleAttack)
+    setGameIsActive,
+  } = useGameState({ handleAttack })
+  const { countdownCount } = useCountDown(3, () => setGameIsActive(true))
 
   return (
     <ThreeKingsContext.Provider

--- a/src/Game/ThreeKings/index.tsx
+++ b/src/Game/ThreeKings/index.tsx
@@ -4,6 +4,7 @@ import { View } from "react-native"
 import Board from "../Board"
 import Hearts from "./Hearts"
 import GameContainer from "../GameContainer"
+import Countdown from "../Countdown"
 import ThreeKingsContext, { ThreeKingsProvider } from "./ThreeKingsContext"
 
 const ThreeKingsGame = () => {
@@ -18,10 +19,10 @@ const ThreeKingsGame = () => {
   } = useContext(ThreeKingsContext)
   return (
     <View>
+      {countdownCount >= 0 ? <Countdown count={countdownCount} /> : null}
       <Hearts livesCount={computerLives} />
       <Board
         board={board}
-        countdownCount={countdownCount}
         userSelectedTile={userSelectedTile}
         computerSelectedTile={computerSelectedTile}
         selectUserTile={selectUserTile}

--- a/src/Game/index.tsx
+++ b/src/Game/index.tsx
@@ -6,6 +6,7 @@ import Header from "../Header"
 import Classic from "./Classic"
 import ThreeKings from "./ThreeKings"
 import Cooldown from "./Cooldown"
+import Playground from "./Playground"
 
 import { Buttons, Colors } from "../styles"
 
@@ -22,6 +23,9 @@ const GameScreen = () => {
       }
       case "Cooldown": {
         return <Cooldown />
+      }
+      case "Playground": {
+        return <Playground />
       }
     }
   }

--- a/src/StartGameButtons.tsx
+++ b/src/StartGameButtons.tsx
@@ -1,50 +1,54 @@
 import React, { useContext } from "react"
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
 
-import AracadeContext from "./ArcadeContext"
+import AracadeContext, { Screens, Games, Game } from "./ArcadeContext"
 
 import { Buttons, Typography } from "./styles"
 
 const StartGameButtons = () => {
-  const { setCurrentGame, setCurrentWinner, goToGame } = useContext(
+  const { setCurrentGame, setCurrentWinner, setCurrentScreen } = useContext(
     AracadeContext
   )
 
-  const handlePressClassGame = () => {
-    setCurrentGame("Classic")
+  const handlePress = (game: Game) => {
+    setCurrentGame(game)
     setCurrentWinner(null)
-    goToGame()
+    setCurrentScreen(Screens.Game)
   }
 
-  const handlePressThreeKings = () => {
-    setCurrentGame("ThreeKings")
-    setCurrentWinner(null)
-    goToGame()
-  }
+  const handlePressClassGame = () => handlePress(Games.Classic)
+  const handlePressThreeKings = () => handlePress(Games.ThreeKings)
+  const handlePressCooldown = () => handlePress(Games.Cooldown)
+  const handlePressPlayground = () => handlePress(Games.Playground)
 
-  const handlePressCooldown = () => {
-    setCurrentGame("Cooldown")
-    setCurrentWinner(null)
-    goToGame()
+  const StartGameButton = ({
+    onPress,
+    title,
+  }: {
+    onPress: () => void
+    title: Game
+  }) => {
+    return (
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity onPress={onPress} style={styles.button}>
+          <Text style={Typography.mainButton}>{title.toUpperCase()}</Text>
+        </TouchableOpacity>
+      </View>
+    )
   }
 
   return (
     <View style={styles.container}>
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity onPress={handlePressClassGame} style={styles.button}>
-          <Text style={Typography.mainButton}>PLAY CLASSIC</Text>
-        </TouchableOpacity>
-      </View>
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity onPress={handlePressThreeKings} style={styles.button}>
-          <Text style={Typography.mainButton}>PLAY 3 KINGS</Text>
-        </TouchableOpacity>
-      </View>
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity onPress={handlePressCooldown} style={styles.button}>
-          <Text style={Typography.mainButton}>COOLDOWN</Text>
-        </TouchableOpacity>
-      </View>
+      <StartGameButton onPress={handlePressClassGame} title={Games.Classic} />
+      <StartGameButton
+        onPress={handlePressThreeKings}
+        title={Games.ThreeKings}
+      />
+      <StartGameButton onPress={handlePressCooldown} title={Games.Cooldown} />
+      <StartGameButton
+        onPress={handlePressPlayground}
+        title={Games.Playground}
+      />
     </View>
   )
 }

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -8,19 +8,39 @@ const base: ViewStyle = {
   justifyContent: "center",
 }
 
+const small: ViewStyle = {
+  padding: 4,
+  width: "80%",
+}
+
 const large: ViewStyle = {
   maxHeight: 60,
   padding: 10,
+}
+
+const square: ViewStyle = {
+  borderRadius: 2,
 }
 
 const rounded: ViewStyle = {
   borderRadius: 30,
 }
 
+const red: ViewStyle = {
+  backgroundColor: Colors.red,
+}
+
 export const largeRounded: ViewStyle = {
   ...base,
   ...large,
   ...rounded,
+}
+
+export const smallSquareRed: ViewStyle = {
+  ...base,
+  ...small,
+  ...square,
+  ...red,
 }
 
 export const primaryContainer: ViewStyle = {

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -7,9 +7,16 @@ export const largeFontSize = 24
 export const countFontSize = 180
 
 export const heavyFontWeight = "600"
+export const heaviestFontWeight = "900"
 
 export const helvetica = "Helvetica-Bold"
 const baseFont = helvetica
+
+export const smallWhiteBold: TextStyle = {
+  color: Colors.white,
+  fontSize: baseFontSize,
+  fontWeight: heaviestFontWeight,
+}
 
 export const landing: TextStyle = {
   color: Colors.white,


### PR DESCRIPTION
Why:
We would like for players to have a stress-free zen version of the game.
We would also like a nice place for us to test out animation and
interaction ideas outside of the context of a game.

This commit:
Adds a playground mode to the game. adds a 'Go To Main Menu' button to
the settings modal so that users may end games early. Some refactoring
was done so that the countdown functionality could be included
independently of the game. The currently screen logic was refactored to
be more general, since we are planning to add more screens that Landing
and Game soon.

---

![playground](https://user-images.githubusercontent.com/16049495/68998802-fbb6fc00-0884-11ea-9d4b-dd9a9e27a11e.gif)
