### PR TITLE
Add menu screen

### DIFF
--- a/src/Arcade.tsx
+++ b/src/Arcade.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet } from "react-native"
 
 import ArcadeContext, { Screens } from "./ArcadeContext"
 import LandingScreen from "./Landing"
+import MenuScreen from "./Menu"
 import GameScreen from "./Game"
 import GameOverScreen from "./GameOver"
 
@@ -13,6 +14,9 @@ const Arcade = () => {
     switch (currentScreen) {
       case Screens.Landing: {
         return <LandingScreen />
+      }
+      case Screens.Menu: {
+        return <MenuScreen />
       }
       case Screens.Game: {
         return currentWinner == null ? <GameScreen /> : <GameOverScreen />

--- a/src/ArcadeContext.tsx
+++ b/src/ArcadeContext.tsx
@@ -10,10 +10,11 @@ export const Games: { [k in Game]: Game } = {
   Playground: "Playground",
 }
 
-export type Screen = "Landing" | "Game"
+export type Screen = "Landing" | "Menu" | "Game"
 
 export const Screens: { [screen in Screen]: Screen } = {
   Landing: "Landing",
+  Menu: "Menu",
   Game: "Game",
 }
 

--- a/src/Game/Settings.tsx
+++ b/src/Game/Settings.tsx
@@ -20,7 +20,7 @@ const Settings = () => {
   const sliderValue = (1100 - computerClockSpeed) / 100
 
   const handleOnPressMainMenu = () => {
-    setCurrentScreen(Screens.Landing)
+    setCurrentScreen(Screens.Menu)
     setGameIsActive(false)
   }
 

--- a/src/GameOver/index.tsx
+++ b/src/GameOver/index.tsx
@@ -1,15 +1,24 @@
 import React, { useContext } from "react"
-import { View, Image, StyleSheet } from "react-native"
+import { View, TouchableOpacity, Text, Image, StyleSheet } from "react-native"
 
 import Header from "../Header"
-import StartGameButtons from "../StartGameButtons"
-import ArcadeContext from "../ArcadeContext"
+import ArcadeContext, { Screens } from "../ArcadeContext"
 
 import { Images } from "../assets"
-import { Spacing } from "../styles"
+import { Spacing, Buttons, Typography } from "../styles"
 
 const GameOver = () => {
-  const { currentWinner } = useContext(ArcadeContext)
+  const { currentWinner, setCurrentWinner, setCurrentScreen } = useContext(
+    ArcadeContext
+  )
+
+  const handleOnPressPlayAgain = () => {
+    setCurrentWinner(null)
+  }
+
+  const handleOnPressMainMenu = () => {
+    setCurrentScreen(Screens.Menu)
+  }
   return (
     <View style={styles.container} testID={"game-over"}>
       <View style={styles.headerContainer}>
@@ -25,7 +34,18 @@ const GameOver = () => {
       </View>
 
       <View style={styles.footer}>
-        <StartGameButtons />
+        <TouchableOpacity
+          onPress={handleOnPressPlayAgain}
+          style={styles.playAgainContainer}
+        >
+          <Text style={styles.playAgainText}>INSERT COIN</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleOnPressMainMenu}
+          style={styles.goToMainContainer}
+        >
+          <Text style={styles.goToMainText}>RETURN TO MAIN MENU</Text>
+        </TouchableOpacity>
       </View>
     </View>
   )
@@ -52,6 +72,20 @@ const styles = StyleSheet.create({
     paddingLeft: Spacing.medium,
     paddingRight: Spacing.medium,
     height: "22%",
+  },
+  playAgainContainer: {
+    ...Buttons.largeBlueBorder,
+  },
+  playAgainText: {
+    ...Typography.largeWhite,
+  },
+  goToMainContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    paddingVertical: Spacing.large,
+  },
+  goToMainText: {
+    ...Typography.smallWhite,
   },
 })
 

--- a/src/Landing/index.tsx
+++ b/src/Landing/index.tsx
@@ -1,16 +1,33 @@
-import React from "react"
-import { View, ImageBackground, StyleSheet } from "react-native"
+import React, { useContext } from "react"
+import {
+  View,
+  Text,
+  ImageBackground,
+  StyleSheet,
+  TouchableOpacity,
+} from "react-native"
 
-import StartGameButtons from "../StartGameButtons"
+import ArcadeContext, { Screens } from "../ArcadeContext"
 
 import { Images } from "../assets"
-import { Spacing } from "../styles"
+import { Spacing, Typography, Buttons } from "../styles"
 
 const LandingScreen = () => {
+  const { setCurrentScreen } = useContext(ArcadeContext)
+  const handleOnPress = () => {
+    setCurrentScreen(Screens.Menu)
+  }
   return (
     <ImageBackground source={Images.Welcome} style={styles.container}>
       <View style={styles.footer}>
-        <StartGameButtons />
+        <View style={styles.insertCoinButtonContainer}>
+          <TouchableOpacity
+            onPress={handleOnPress}
+            style={styles.insertCoinButton}
+          >
+            <Text style={styles.insertCoinText}>Insert Coin</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </ImageBackground>
   )
@@ -22,9 +39,19 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   footer: {
+    justifyContent: "center",
     paddingLeft: Spacing.medium,
     paddingRight: Spacing.medium,
     height: "22%",
+  },
+  insertCoinButtonContainer: {
+    ...Buttons.primaryContainer,
+  },
+  insertCoinButton: {
+    ...Buttons.primary,
+  },
+  insertCoinText: {
+    ...Typography.mainButton,
   },
 })
 

--- a/src/Menu/GameModeList.tsx
+++ b/src/Menu/GameModeList.tsx
@@ -1,11 +1,17 @@
 import React, { useContext } from "react"
-import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import {
+  View,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from "react-native"
 
-import AracadeContext, { Screens, Games, Game } from "./ArcadeContext"
+import AracadeContext, { Screens, Games, Game } from "../ArcadeContext"
 
-import { Buttons, Typography } from "./styles"
+import { Typography, Colors } from "../styles"
 
-const StartGameButtons = () => {
+const GameModeList = () => {
   const { setCurrentGame, setCurrentWinner, setCurrentScreen } = useContext(
     AracadeContext
   )
@@ -38,7 +44,7 @@ const StartGameButtons = () => {
   }
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.container}>
       <StartGameButton onPress={handlePressClassGame} title={Games.Classic} />
       <StartGameButton
         onPress={handlePressThreeKings}
@@ -49,22 +55,24 @@ const StartGameButtons = () => {
         onPress={handlePressPlayground}
         title={Games.Playground}
       />
-    </View>
+    </ScrollView>
   )
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     width: "100%",
-    justifyContent: "space-between",
   },
   buttonContainer: {
-    ...Buttons.primaryContainer,
+    paddingVertical: 12,
   },
   button: {
-    ...Buttons.primary,
+    backgroundColor: Colors.white,
+    height: 120,
+    borderRadius: 4,
+    paddingHorizontal: 20,
+    paddingTop: 12,
   },
 })
 
-export default StartGameButtons
+export default GameModeList

--- a/src/Menu/index.tsx
+++ b/src/Menu/index.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+import { View, StyleSheet } from "react-native"
+
+import Header from "../Header"
+import GameModeList from "./GameModeList"
+
+import { Spacing } from "../styles"
+
+const MenuScreen = () => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerContainer}>
+        <Header />
+      </View>
+      <View style={styles.gameModeListContainer}>
+        <GameModeList />
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: Spacing.medium,
+    paddingBottom: Spacing.xLarge,
+  },
+  headerContainer: {
+    height: "22%",
+    justifyContent: "flex-start",
+    width: "100%",
+    paddingTop: Spacing.medium,
+  },
+  gameModeListContainer: {
+    flex: 1,
+    paddingTop: Spacing.large,
+    paddingHorizontal: Spacing.medium,
+  },
+})
+
+export default MenuScreen

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -43,9 +43,18 @@ export const smallSquareRed: ViewStyle = {
   ...red,
 }
 
+export const largeBlueBorder: ViewStyle = {
+  ...base,
+  ...large,
+  ...rounded,
+  borderWidth: 1,
+  borderColor: Colors.blue,
+  backgroundColor: Colors.transparentFull,
+}
+
 export const primaryContainer: ViewStyle = {
   backgroundColor: Colors.white,
-  height: Spacing.xLarge,
+  height: Spacing.xxLarge,
   borderRadius: Spacing.large,
   padding: Spacing.xSmall,
 }

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -9,6 +9,7 @@ export const red = "#c93101"
 
 export const transparentDark = "rgba(11,11,11,0.7)"
 export const transparentWhite = "rgba(255,255,255,0.9)"
+export const transparentFull = "rgba(255,255,255,0.0)"
 
 export const background = black
 export const tileBlack = darkGray

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -18,6 +18,17 @@ export const smallWhiteBold: TextStyle = {
   fontWeight: heaviestFontWeight,
 }
 
+export const smallWhite: TextStyle = {
+  color: Colors.white,
+  fontSize: baseFontSize,
+}
+
+export const largeWhite: TextStyle = {
+  color: Colors.white,
+  fontSize: largeFontSize,
+  fontWeight: heaviestFontWeight,
+}
+
 export const landing: TextStyle = {
   color: Colors.white,
   fontSize: largeFontSize,


### PR DESCRIPTION
Why:
We would like players to be able to select the game mode they'd like to
play from a dedicated menu screen.

This commit:
Introduces a menu screen for game modes. Updates the landing page to
have an 'Insert Coin' button to move to the menu screen. Updates the
game over screen to have an 'Insert Coin' Button and a return to the
main menu button.

---

![menu](https://user-images.githubusercontent.com/16049495/68999278-b696c800-088c-11ea-9c5b-d61f7d955f8b.gif)
